### PR TITLE
Uses default xml2rfc options on conversions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,6 +15,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    # Required OS dependencies
+    - name: Install xml2rfc OS dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y software-properties-common gcc
+        sudo apt-get install -y python3-cffi python3-brotli libpango-1.0-0 libharfbuzz0b libpangoft2-1.0-0 libcairo2-dev libpangocairo-1.0-0
     # Python
     - name: Set up Python 3.8
       uses: actions/setup-python@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update
 RUN apt-get install -y software-properties-common gcc wget
 RUN apt-get install -y ruby python3.8 python3-pip
 # xml2rfc (Weasyprint) dependencies
-RUN apt-get install -y python3-cffi python3-brotli libpango-1.0-0 libharfbuzz0b libpangoft2-1.0-0
+RUN apt-get install -y python3-cffi python3-brotli libpango-1.0-0 libharfbuzz0b libpangoft2-1.0-0 libcairo2-dev libpangocairo-1.0-0
 # install kramdown-rfc2629 dependencies
 RUN apt-get install -y golang git
 ENV GOPATH=/

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,5 +1,6 @@
 appdirs==1.4.4
-Brotli==1.0.9
+cairocffi==1.2.0
+CairoSVG==2.5.2
 certifi==2021.5.30
 cffi==1.14.6
 charset-normalizer==2.0.6
@@ -7,9 +8,9 @@ click==8.0.1
 ConfigArgParse==1.5.2
 cssselect2==0.4.1
 decorator==5.1.0
+defusedxml==0.7.1
 Flask==2.0.1
 Flask-Cors==3.0.10
-fonttools==4.27.0
 google-i18n-address==2.5.0
 html5lib==1.1
 id2xml==1.5.0
@@ -22,9 +23,9 @@ lxml==4.6.3
 MarkupSafe==2.0.1
 pathlib2==2.3.6
 Pillow==8.3.2
+pycairo==1.19.1
 pycountry==20.7.3
 pycparser==2.20
-pydyf==0.1.1
 pyflakes==2.3.1
 pyphen==0.11.0
 PyYAML==5.4.1
@@ -34,9 +35,8 @@ six==1.16.0
 sortedcontainers==2.4.0
 svgcheck==0.6.0
 tinycss2==1.1.0
-urllib3==1.26.6
-weasyprint==53.0
+urllib3==1.26.7
+WeasyPrint==52.5
 webencodings==0.5.1
 Werkzeug==2.0.1
 xml2rfc==3.10.0
-zopfli==0.1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ decorator>=5.1.0
 Flask>=2.0.1
 flask-cors>=3.0.10
 id2xml>=1.5.0
+pycairo<1.20
 requests>=2.26.0
 svgcheck>=0.6.0
-weasyprint==53.0
+weasyprint==52.5
 xml2rfc>=3.10.0

--- a/tests/data/draft-smoke-signals-00.xml
+++ b/tests/data/draft-smoke-signals-00.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="rfc2629.xslt" ?>
-<!DOCTYPE rfc SYSTEM "rfc2629.dtd" []>
 <?rfc toc="yes"?>
 <?rfc sortrefs="yes"?>
 <?rfc symrefs="yes"?>

--- a/tests/test_utils_processor.py
+++ b/tests/test_utils_processor.py
@@ -4,10 +4,9 @@ from shutil import copy, rmtree
 from unittest import TestCase
 
 from werkzeug.datastructures import FileStorage
-from xml2rfc.parser import XmlRfc
 
 from at.utils.processor import (
-        convert_v2v3, get_html, get_pdf, get_text, get_xml, md2xml, prep_xml,
+        convert_v2v3, get_html, get_pdf, get_text, get_xml, md2xml,
         process_file)
 
 TEST_DATA_DIR = './tests/data/'
@@ -80,11 +79,6 @@ class TestUtilsProcessor(TestCase):
 
             self.assertTrue(Path(saved_file).exists())
             self.assertEqual(Path(saved_file).suffix, '.xml')
-
-    def test_prep_xml(self):
-        xml = prep_xml(''.join([TEMPORARY_DATA_DIR, TEST_XML_DRAFT]))
-
-        self.assertIsInstance(xml, XmlRfc)
 
     def test_get_html(self):
         saved_file = get_html(


### PR DESCRIPTION
Due to the complexity of how xml2rfc options are set,
ietf-at is moving to using xml2rfc as a command rather than library for
v2v3, pdf, text, html conversions.

This change also removed the preptool step since it's unnecessary when
moved to xml2rfc command based conversions.

Fixes #11 