### PR TITLE
Feature/iddiff allow other formats

### DIFF
--- a/at/utils/file.py
+++ b/at/utils/file.py
@@ -8,7 +8,6 @@ from requests.exceptions import ConnectionError, Timeout
 from werkzeug.utils import secure_filename
 
 ALLOWED_EXTENSIONS = ('txt', 'xml', 'md', 'mkd',)
-ALLOWED_DIFF_EXTENSIONS = ('txt',)
 DIR_MODE = 0o770
 DRAFT_VERSION = re_compile(r'-\d+(.txt)?$')
 OK = 200
@@ -20,13 +19,11 @@ class DownloadError(Exception):
     pass
 
 
-def allowed_file(filename, diff=False):
+def allowed_file(filename):
     '''Return true if file extension in allowed list'''
 
-    extensions = ALLOWED_DIFF_EXTENSIONS if diff else ALLOWED_EXTENSIONS
-
     return '.' in filename and \
-           filename.rsplit('.', 1)[1].lower() in extensions
+           filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
 
 
 def get_extension(filename):

--- a/at/utils/processor.py
+++ b/at/utils/processor.py
@@ -138,7 +138,7 @@ def convert_v2v3(filename, logger=getLogger()):
     '''Convert XML2RFC v2 file to v3'''
     logger.debug('converting v2 XML to v3 XML')
 
-    xml_file = get_filename(filename, 'v2v3.xml')
+    xml_file = get_filename(filename, 'xml')
 
     output = proc_run(
                 args=[

--- a/tests/test_utils_file.py
+++ b/tests/test_utils_file.py
@@ -10,8 +10,7 @@ from werkzeug.datastructures import FileStorage
 
 from at.utils.file import (
         allowed_file, get_file, get_filename, get_name, save_file,
-        save_file_from_url, ALLOWED_EXTENSIONS, ALLOWED_DIFF_EXTENSIONS,
-        DownloadError)
+        save_file_from_url, ALLOWED_EXTENSIONS, DownloadError)
 
 TEST_DATA_DIR = './tests/data/'
 TEST_XML_DRAFT = 'draft-smoke-signals-00.xml'
@@ -49,24 +48,11 @@ class TestUtilsFile(TestCase):
 
         self.assertFalse(allowed_file(filename))
 
-    @given(text())
-    def test_allowed_file_for_non_supported_diff(self, filename):
-        for extension in ALLOWED_DIFF_EXTENSIONS:
-            assume(not filename.endswith(extension))
-
-        self.assertFalse(allowed_file(filename, diff=True))
-
     def test_allowed_file_for_supported(self):
         for extension in ALLOWED_EXTENSIONS:
             filename = self.faker.file_name(extension=extension)
 
             self.assertTrue(allowed_file(filename))
-
-    def test_allowed_file_for_supported_diff(self):
-        for extension in ALLOWED_DIFF_EXTENSIONS:
-            filename = self.faker.file_name(extension=extension)
-
-            self.assertTrue(allowed_file(filename, diff=True))
 
     def test_get_filename(self):
         for extension in ALLOWED_EXTENSIONS:

--- a/tests/test_utils_iddiff.py
+++ b/tests/test_utils_iddiff.py
@@ -1,14 +1,26 @@
 from logging import disable as set_logger, INFO, CRITICAL
+from pathlib import Path
+from shutil import rmtree
 from unittest import TestCase
 
 import responses
+from werkzeug.datastructures import FileStorage
 
 from at.utils.iddiff import (
-        get_id_diff, get_latest, IddiffError, LatestDraftNotFound)
+        get_id_diff, get_latest, get_text_id, IddiffError, LatestDraftNotFound)
 
 TEST_DATA_DIR = './tests/data/'
 DRAFT_A = 'draft-smoke-signals-00.txt'
 DRAFT_B = 'draft-smoke-signals-01.txt'
+TEST_XML_DRAFT = 'draft-smoke-signals-00.xml'
+TEST_XML_V2_DRAFT = 'draft-smoke-signals-00.v2.xml'
+TEST_KRAMDOWN_DRAFT = 'draft-smoke-signals-00.md'
+TEST_MMARK_DRAFT = 'draft-smoke-signals-00.mmark.md'
+TEST_XML_ERROR = 'draft-smoke-signals-00.error.xml'
+TEST_DATA = [
+        TEST_XML_DRAFT, TEST_XML_V2_DRAFT, DRAFT_A, DRAFT_B,
+        TEST_KRAMDOWN_DRAFT, TEST_MMARK_DRAFT]
+TEMPORARY_DATA_DIR = './tests/tmp/'
 DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/doc/rfcdiff-latest-json'
 
 
@@ -18,10 +30,14 @@ class TestUtilsIddiff(TestCase):
     def setUp(self):
         # susspress logging messages
         set_logger(CRITICAL)
+        # create temporary data dir
+        Path(TEMPORARY_DATA_DIR).mkdir(exist_ok=True)
 
     def tearDown(self):
         # set logging to INFO
         set_logger(INFO)
+        # remove temporary data dir
+        rmtree(TEMPORARY_DATA_DIR, ignore_errors=True)
 
     def test_get_id_diff_error(self):
         with self.assertRaises(IddiffError):
@@ -61,3 +77,20 @@ class TestUtilsIddiff(TestCase):
         rfc = 'rfc666'
         latest_draft_url = get_latest(rfc, DT_LATEST_DRAFT_URL)
         self.assertTrue(latest_draft_url.startswith('https://'))
+
+    def test_get_text_id(self):
+        for filename in TEST_DATA:
+            with open(''.join([TEST_DATA_DIR, filename]), 'rb') as file:
+                file_object = FileStorage(file, filename=filename)
+                (dir_path, file_path) = get_text_id(file_object,
+                                                    TEMPORARY_DATA_DIR)
+                self.assertTrue(Path(dir_path).exists())
+                self.assertTrue(Path(file_path).exists())
+                self.assertEqual(Path(file_path).suffix, '.txt')
+
+    def test_get_text_id_error(self):
+        filename = TEST_XML_ERROR
+        with open(''.join([TEST_DATA_DIR, filename]), 'rb') as file:
+            file_object = FileStorage(file, filename=filename)
+            with self.assertRaises(IddiffError):
+                get_text_id(file_object, TEMPORARY_DATA_DIR)


### PR DESCRIPTION
* Allows iddiff to accept non-text files.
* Avoids adding v2v3 on to file name on v2 to v3 conversions.