### PR TITLE
Feature/iddiff urls

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,7 +37,7 @@ jobs:
         grep -v xml2rfc requirements.txt > requirements2.txt
         pip install -r requirements2.txt
         pip uninstall -y jinja2
-        pip install xml2rfc==3.9.1
+        pip install xml2rfc==3.12.1
         pip install -r requirements.dev.txt
     # Ruby
     - name: Set up Ruby

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,9 +78,10 @@ mkdir tmp
 * Create a configuration file.
 ```
 echo "UPLOAD_DIR = '$PWD/tmp'" > at/config.py
-echo "VERSION = '0.0.1'" >> at/config.py
+echo "VERSION = '9.9.9'" >> at/config.py
 echo "DT_APPAUTH_URL = 'https://datatracker.ietf.org/api/appauth/authortools'" >> at/config.py
 echo "DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/doc/rfcdiff-latest-json'" >> at/config.py
+echo "IDDIFF_ALLOWED_DOMAINS = ['ietf.org', 'ietf.org', 'rfc-editor.org']" >> at/config.py
 ```
 
 * Run flask server.

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN echo "UPLOAD_DIR = '$PWD/tmp'" > at/config.py
 RUN echo "VERSION = '0.3.1'" >> at/config.py
 RUN echo "DT_APPAUTH_URL = 'https://datatracker.ietf.org/api/appauth/authortools'" >> at/config.py
 RUN echo "DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/doc/rfcdiff-latest-json'" >> at/config.py
+RUN echo "IDDIFF_ALLOWED_DOMAINS = ['ietf.org', 'ietf.org', 'rfc-editor.org', 'githubusercontent.com', 'github.io', 'gitlab.com']" >> at/config.py
 
 # host with waitress
 RUN pip3 install waitress

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    kramdown-rfc2629 (1.5.24)
+    kramdown-rfc2629 (1.5.25)
       certified (~> 1.0)
       json_pure (~> 2.0)
       kramdown (~> 2.3.0)

--- a/api.yml
+++ b/api.yml
@@ -270,13 +270,19 @@ paths:
                 file_2:
                   type: string
                   format: binary
-                  description: kramdown-rfc2629/mmark (.md, .mkd) file or xml2rfc v2/v3 (.xml) file or text draft (.txt). This is optional. If file_2 and id_2 are not provided, second draft will be identified based on the first draft or first draft file name.
+                  description: kramdown-rfc2629/mmark (.md, .mkd) file or xml2rfc v2/v3 (.xml) file or text draft (.txt). This is optional. If file_2, id_2 or url_2 is not provided, second draft will be identified based on the first draft or first draft file name.
                 id_1:
                   type: string
                   description: First draft name unless file_1 is provided.
                 id_2:
                   type: string
-                  description: Second draft name unless file_2 is provided. This is optional. If file_2 and id_2 are not provided, second draft will be identified based on the first draft or first draft file name.
+                  description: Second draft name unless file_2 is provided. This is optional. If file_2, id_2 or url_2 is not provided, second draft will be identified based on the first draft or first draft file name.
+                url_1:
+                  type: string
+                  description: First draft URL unless file_1 or id_1 is provided.
+                url_2:
+                  type: string
+                  description: Second draft URL unless file_2 or id_2 is provided. This is optional. If file_2, id_2 or url_2 is not provided, second draft will be identified based on the first draft or first draft file name.
                 table:
                   type: string
                   description: If this property is set, HTML table is returned.
@@ -317,13 +323,22 @@ paths:
           name: id_1
           schema:
             type: string
-          description: First draft name unless file_1 is provided.
-          required: true
+          description: First draft name unless id_1 is provided.
         - in: query
           name: id_2
           schema:
             type: string
-          description: Second draft name unless file_2 is provided. This is optional. If file_2 and id_2 are not provided, second draft will be identified based on the first draft or first draft file name.
+          description: Second draft name unless url_2 is provided. This is optional. If id_2 and url_2 are not provided, second draft will be identified based on the first draft or first draft file name.
+        - in: query
+          name: url_1
+          schema:
+            type: string
+          description: First draft URL unless id_1 is provided.
+        - in: query
+          name: url_2
+          schema:
+            type: string
+          description: Second draft URL unless id_2 is provided. This is optional. If id_2 and url_2 are not provided, second draft will be identified based on the first draft or first draft file name.
         - in: query
           name: table
           schema:

--- a/constraints.txt
+++ b/constraints.txt
@@ -40,4 +40,4 @@ urllib3==1.26.7
 WeasyPrint==52.5
 webencodings==0.5.1
 Werkzeug==2.0.2
-xml2rfc==3.12.0
+xml2rfc==3.12.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "aasvg": "^0.1.7"
+        "aasvg": "^0.1.8"
       }
     },
     "node_modules/aasvg": {

--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kesara/ietf-at.git"
+    "url": "git+https://github.com/ietf-tools/ietf-at.git"
   },
   "author": "Kesara Rathnayake",
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
-    "url": "https://github.com/kesara/ietf-at/issues"
+    "url": "https://github.com/ietf-tools/ietf-at/issues"
   },
-  "homepage": "https://github.com/kesara/ietf-at#readme",
+  "homepage": "https://github.com/ietf-tools/ietf-at#readme",
   "dependencies": {
-    "aasvg": "^0.1.7"
+    "aasvg": "^0.1.8"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pycairo<1.20
 requests>=2.26.0
 svgcheck>=0.6.0
 weasyprint==52.5
-xml2rfc>=3.12.0
+xml2rfc>=3.12.1


### PR DESCRIPTION
* Implement iddiff with URL inputs. Fixes #62.
* Update dependencies.

This change introduces a new configuration option `IDDIFF_ALLOWED_DOMAINS`.
This takes a list of second-level domain names and those domains and any subdomains of that list will be allowed in iddiff URL inputs.

Current list of allowed domains are: `['ietf.org', 'ietf.org', 'rfc-editor.org', 'githubusercontent.com', 'github.io', 'gitlab.com']`