### PR TITLE
Bugfix/iddiff fixes

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -270,19 +270,19 @@ paths:
                 file_2:
                   type: string
                   format: binary
-                  description: kramdown-rfc2629/mmark (.md, .mkd) file or xml2rfc v2/v3 (.xml) file or text draft (.txt). This is optional. If file_2, id_2 or url_2 is not provided, second draft will be identified based on the first draft or first draft file name.
-                id_1:
+                  description: kramdown-rfc2629/mmark (.md, .mkd) file or xml2rfc v2/v3 (.xml) file or text draft (.txt). This is optional. If file_2, doc_2 or url_2 is not provided, second draft will be identified based on the first draft or first draft file name.
+                doc_1:
                   type: string
                   description: First draft name unless file_1 is provided.
-                id_2:
+                doc_2:
                   type: string
-                  description: Second draft name unless file_2 is provided. This is optional. If file_2, id_2 or url_2 is not provided, second draft will be identified based on the first draft or first draft file name.
+                  description: Second draft name unless file_2 is provided. This is optional. If file_2, doc_2 or url_2 is not provided, second draft will be identified based on the first draft or first draft file name.
                 url_1:
                   type: string
-                  description: First draft URL unless file_1 or id_1 is provided.
+                  description: First draft URL unless file_1 or doc_1 is provided.
                 url_2:
                   type: string
-                  description: Second draft URL unless file_2 or id_2 is provided. This is optional. If file_2, id_2 or url_2 is not provided, second draft will be identified based on the first draft or first draft file name.
+                  description: Second draft URL unless file_2 or doc_2 is provided. This is optional. If file_2, doc_2 or url_2 is not provided, second draft will be identified based on the first draft or first draft file name.
                 table:
                   type: string
                   description: If this property is set, HTML table is returned.
@@ -320,25 +320,25 @@ paths:
       summary: Validates the draft
       parameters:
         - in: query
-          name: id_1
+          name: doc_1
           schema:
             type: string
-          description: First draft name unless id_1 is provided.
+          description: First draft name unless doc_1 is provided.
         - in: query
-          name: id_2
+          name: doc_2
           schema:
             type: string
-          description: Second draft name unless url_2 is provided. This is optional. If id_2 and url_2 are not provided, second draft will be identified based on the first draft or first draft file name.
+          description: Second draft name unless url_2 is provided. This is optional. If doc_2 and url_2 are not provided, second draft will be identified based on the first draft or first draft file name.
         - in: query
           name: url_1
           schema:
             type: string
-          description: First draft URL unless id_1 is provided.
+          description: First draft URL unless doc_1 is provided.
         - in: query
           name: url_2
           schema:
             type: string
-          description: Second draft URL unless id_2 is provided. This is optional. If id_2 and url_2 are not provided, second draft will be identified based on the first draft or first draft file name.
+          description: Second draft URL unless doc_2 is provided. This is optional. If doc_2 and url_2 are not provided, second draft will be identified based on the first draft or first draft file name.
         - in: query
           name: table
           schema:

--- a/at/api.py
+++ b/at/api.py
@@ -151,6 +151,15 @@ def id_diff():
     url_1 = request.values.get('url_1', '').strip()
     url_2 = request.values.get('url_2', '').strip()
 
+    # allow single parameters for doc_? and url_?
+    if 'file_1' not in request.files and not doc_1 and not url_1:
+        if doc_2:
+            doc_1 = doc_2
+            doc_2 = ''
+        elif url_2:
+            url_1 = url_2
+            url_2 = ''
+
     single_draft = False
 
     if request.values.get('table', False):
@@ -160,8 +169,8 @@ def id_diff():
 
     if not doc_1 and not url_1:
         if 'file_1' not in request.files:
-            logger.info('missing first draft')
-            return jsonify(error='Missing first draft'), BAD_REQUEST
+            logger.info('no documents to compare')
+            return jsonify(error='No documents to compare'), BAD_REQUEST
         else:
             file_1 = request.files['file_1']
 

--- a/at/api.py
+++ b/at/api.py
@@ -146,8 +146,8 @@ def id_diff():
 
     logger = current_app.logger
 
-    id_1 = request.values.get('id_1', '').strip()
-    id_2 = request.values.get('id_2', '').strip()
+    doc_1 = request.values.get('doc_1', '').strip()
+    doc_2 = request.values.get('doc_2', '').strip()
     url_1 = request.values.get('url_1', '').strip()
     url_2 = request.values.get('url_2', '').strip()
 
@@ -158,7 +158,7 @@ def id_diff():
     else:
         table = False
 
-    if not id_1 and not url_1:
+    if not doc_1 and not url_1:
         if 'file_1' not in request.files:
             logger.info('missing first draft')
             return jsonify(error='Missing first draft'), BAD_REQUEST
@@ -184,9 +184,9 @@ def id_diff():
                                                             file_1.filename))
             return jsonify(
                         error='First file format not supported'), BAD_REQUEST
-    elif id_1:
+    elif doc_1:
         try:
-            url = get_latest(id_1,
+            url = get_latest(doc_1,
                              current_app.config['DT_LATEST_DRAFT_URL'],
                              logger)
         except LatestDraftNotFound as e:
@@ -215,14 +215,14 @@ def id_diff():
         except DownloadError as e:
             return jsonify(error=str(e)), BAD_REQUEST
 
-    if not id_2 and not url_2:
+    if not doc_2 and not url_2:
         if 'file_2' not in request.files:
             if 'file_1' in request.files:
                 draft_name = get_name(file_1.filename)
                 original_draft = get_name_with_revision(file_1.filename)
-            elif id_1:
-                draft_name = get_name(id_1)
-                original_draft = get_name_with_revision(id_1)
+            elif doc_1:
+                draft_name = get_name(doc_1)
+                original_draft = get_name_with_revision(doc_1)
             else:
                 filename = filename_1.split('/')[-1]
                 draft_name = get_name(filename)
@@ -270,9 +270,9 @@ def id_diff():
                                                             file_2.filename))
                 return jsonify(
                         error='Second file format not supported'), BAD_REQUEST
-    elif id_2:
+    elif doc_2:
         try:
-            url = get_latest(id_2,
+            url = get_latest(doc_2,
                              current_app.config['DT_LATEST_DRAFT_URL'],
                              logger)
         except LatestDraftNotFound as e:

--- a/tests/test_api_iddiff.py
+++ b/tests/test_api_iddiff.py
@@ -235,20 +235,20 @@ class TestApiIddiff(TestCase):
 
         with self.app.test_client() as client:
             with self.app.app_context():
-                for (id_1, id_2) in pairs:
+                for (doc_1, doc_2) in pairs:
                     result = client.post(
                             '/api/iddiff',
                             data={
-                                'id_1': id_1,
-                                'id_2': id_2,
+                                'doc_1': doc_1,
+                                'doc_2': doc_2,
                                 'apikey': VALID_API_KEY})
 
                     data = result.get_data()
 
                     self.assertEqual(result.status_code, 200)
                     self.assertIn(b'<html lang="en">', data)
-                    self.assertIn(str.encode(id_1), data)
-                    self.assertIn(str.encode(id_2), data)
+                    self.assertIn(str.encode(doc_1), data)
+                    self.assertIn(str.encode(doc_2), data)
 
     def test_iddiff_get_with_two_labels(self):
         pairs = [
@@ -259,19 +259,19 @@ class TestApiIddiff(TestCase):
 
         with self.app.test_client() as client:
             with self.app.app_context():
-                for (id_1, id_2) in pairs:
+                for (doc_1, doc_2) in pairs:
                     result = client.get(
                             '/api/iddiff?' + urlencode({
-                                'id_1': id_1,
-                                'id_2': id_2}),
+                                'doc_1': doc_1,
+                                'doc_2': doc_2}),
                             headers={'X-API-KEY': VALID_API_KEY})
 
                     data = result.get_data()
 
                     self.assertEqual(result.status_code, 200)
                     self.assertIn(b'<html lang="en">', data)
-                    self.assertIn(str.encode(id_1), data)
-                    self.assertIn(str.encode(id_2), data)
+                    self.assertIn(str.encode(doc_1), data)
+                    self.assertIn(str.encode(doc_2), data)
 
     def test_iddiff_with_one_file(self):
         with self.app.test_client() as client:
@@ -305,7 +305,7 @@ class TestApiIddiff(TestCase):
                     result = client.post(
                             '/api/iddiff',
                             data={
-                                'id_1': id,
+                                'doc_1': id,
                                 'apikey': VALID_API_KEY})
 
                     data = result.get_data()
@@ -325,7 +325,7 @@ class TestApiIddiff(TestCase):
             with self.app.app_context():
                 for id in labels:
                     result = client.get(
-                            '/api/iddiff?' + urlencode({'id_1': id}),
+                            '/api/iddiff?' + urlencode({'doc_1': id}),
                             headers={'X-API-KEY': VALID_API_KEY})
 
                     data = result.get_data()
@@ -345,7 +345,7 @@ class TestApiIddiff(TestCase):
                             'file_1': (
                                 open(get_path(DRAFT_A), 'rb'),
                                 DRAFT_A),
-                            'id_2': draft_name,
+                            'doc_2': draft_name,
                             'apikey': VALID_API_KEY})
 
                 data = result.get_data()
@@ -363,7 +363,7 @@ class TestApiIddiff(TestCase):
                 result = client.post(
                         '/api/iddiff',
                         data={
-                            'id_1': draft_name,
+                            'doc_1': draft_name,
                             'file_2': (
                                 open(get_path(DRAFT_A), 'rb'),
                                 DRAFT_A),
@@ -409,7 +409,7 @@ class TestApiIddiff(TestCase):
                     result = client.post(
                             '/api/iddiff',
                             data={
-                                'id_1': id,
+                                'doc_1': id,
                                 'table': 1,
                                 'apikey': VALID_API_KEY})
 
@@ -498,8 +498,8 @@ class TestApiIddiff(TestCase):
     def test_iddiff_with_two_urls(self):
         url_1 = 'https://www.ietf.org/archive/id/draft-iab-xml2rfcv2-01.xml'
         url_2 = 'https://www.ietf.org/archive/id/draft-iab-xml2rfcv2-02.xml'
-        id_1 = 'draft-iab-xml2rfcv2-01'
-        id_2 = 'draft-iab-xml2rfcv2-01'
+        doc_1 = 'draft-iab-xml2rfcv2-01'
+        doc_2 = 'draft-iab-xml2rfcv2-01'
 
         with self.app.test_client() as client:
             with self.app.app_context():
@@ -514,14 +514,14 @@ class TestApiIddiff(TestCase):
 
                 self.assertEqual(result.status_code, 200)
                 self.assertIn(b'<html lang="en">', data)
-                self.assertIn(str.encode(id_1), data)
-                self.assertIn(str.encode(id_2), data)
+                self.assertIn(str.encode(doc_1), data)
+                self.assertIn(str.encode(doc_2), data)
 
     def test_iddiff_get_with_two_urls(self):
         url_1 = 'https://www.ietf.org/archive/id/draft-iab-xml2rfcv2-01.xml'
         url_2 = 'https://www.ietf.org/archive/id/draft-iab-xml2rfcv2-02.xml'
-        id_1 = 'draft-iab-xml2rfcv2-01'
-        id_2 = 'draft-iab-xml2rfcv2-01'
+        doc_1 = 'draft-iab-xml2rfcv2-01'
+        doc_2 = 'draft-iab-xml2rfcv2-01'
 
         with self.app.test_client() as client:
             with self.app.app_context():
@@ -535,5 +535,5 @@ class TestApiIddiff(TestCase):
 
                 self.assertEqual(result.status_code, 200)
                 self.assertIn(b'<html lang="en">', data)
-                self.assertIn(str.encode(id_1), data)
-                self.assertIn(str.encode(id_2), data)
+                self.assertIn(str.encode(doc_1), data)
+                self.assertIn(str.encode(doc_2), data)

--- a/tests/test_api_iddiff.py
+++ b/tests/test_api_iddiff.py
@@ -76,7 +76,7 @@ class TestApiIddiff(TestCase):
                 json_data = result.get_json()
 
                 self.assertEqual(result.status_code, 400)
-                self.assertEqual(json_data['error'], 'Missing first draft')
+                self.assertEqual(json_data['error'], 'No documents to compare')
 
     def test_get_no_label(self):
         with self.app.test_client() as client:
@@ -87,7 +87,7 @@ class TestApiIddiff(TestCase):
                 json_data = result.get_json()
 
                 self.assertEqual(result.status_code, 400)
-                self.assertEqual(json_data['error'], 'Missing first draft')
+                self.assertEqual(json_data['error'], 'No documents to compare')
 
     def test_missing_first_file_name(self):
         with self.app.test_client() as client:
@@ -302,17 +302,18 @@ class TestApiIddiff(TestCase):
         with self.app.test_client() as client:
             with self.app.app_context():
                 for id in labels:
-                    result = client.post(
-                            '/api/iddiff',
-                            data={
-                                'doc_1': id,
-                                'apikey': VALID_API_KEY})
+                    for param in ('doc_1', 'doc_2'):
+                        result = client.post(
+                                '/api/iddiff',
+                                data={
+                                    param: id,
+                                    'apikey': VALID_API_KEY})
 
-                    data = result.get_data()
+                        data = result.get_data()
 
-                    self.assertEqual(result.status_code, 200)
-                    self.assertIn(b'<html lang="en">', data)
-                    self.assertIn(str.encode(id), data)
+                        self.assertEqual(result.status_code, 200)
+                        self.assertIn(b'<html lang="en">', data)
+                        self.assertIn(str.encode(id), data)
 
     def test_iddiff_get_with_one_label(self):
         labels = [
@@ -324,15 +325,16 @@ class TestApiIddiff(TestCase):
         with self.app.test_client() as client:
             with self.app.app_context():
                 for id in labels:
-                    result = client.get(
-                            '/api/iddiff?' + urlencode({'doc_1': id}),
-                            headers={'X-API-KEY': VALID_API_KEY})
+                    for param in ('doc_1', 'doc_2'):
+                        result = client.get(
+                                '/api/iddiff?' + urlencode({param: id}),
+                                headers={'X-API-KEY': VALID_API_KEY})
 
-                    data = result.get_data()
+                        data = result.get_data()
 
-                    self.assertEqual(result.status_code, 200)
-                    self.assertIn(b'<html lang="en">', data)
-                    self.assertIn(str.encode(id), data)
+                        self.assertEqual(result.status_code, 200)
+                        self.assertIn(b'<html lang="en">', data)
+                        self.assertIn(str.encode(id), data)
 
     def test_iddiff_with_label_and_file(self):
         with self.app.test_client() as client:
@@ -467,17 +469,18 @@ class TestApiIddiff(TestCase):
 
         with self.app.test_client() as client:
             with self.app.app_context():
-                result = client.post(
-                            '/api/iddiff',
-                            data={
-                                'url_1': valid,
-                                'apikey': VALID_API_KEY})
+                for param in ('url_1', 'url_2'):
+                    result = client.post(
+                                '/api/iddiff',
+                                data={
+                                    param: valid,
+                                    'apikey': VALID_API_KEY})
 
-                data = result.get_data()
+                    data = result.get_data()
 
-                self.assertEqual(result.status_code, 200)
-                self.assertIn(b'<html lang="en">', data)
-                self.assertIn(str.encode(id), data)
+                    self.assertEqual(result.status_code, 200)
+                    self.assertIn(b'<html lang="en">', data)
+                    self.assertIn(str.encode(id), data)
 
     def test_iddiff_get_with_one_url(self):
         valid = 'https://www.ietf.org/archive/id/draft-iab-xml2rfcv2-02.xml'
@@ -485,15 +488,16 @@ class TestApiIddiff(TestCase):
 
         with self.app.test_client() as client:
             with self.app.app_context():
-                result = client.get(
-                            '/api/iddiff?' + urlencode({'url_1': valid}),
-                            headers={'X-API-KEY': VALID_API_KEY})
+                for param in ('url_1', 'url_2'):
+                    result = client.get(
+                                '/api/iddiff?' + urlencode({param: valid}),
+                                headers={'X-API-KEY': VALID_API_KEY})
 
-                data = result.get_data()
+                    data = result.get_data()
 
-                self.assertEqual(result.status_code, 200)
-                self.assertIn(b'<html lang="en">', data)
-                self.assertIn(str.encode(id), data)
+                    self.assertEqual(result.status_code, 200)
+                    self.assertIn(b'<html lang="en">', data)
+                    self.assertIn(str.encode(id), data)
 
     def test_iddiff_with_two_urls(self):
         url_1 = 'https://www.ietf.org/archive/id/draft-iab-xml2rfcv2-01.xml'


### PR DESCRIPTION
* Change iddiff parameters id_1 and id_2 to doc_1 and doc_2. FIxes #66 
* Allow any single `url` or `doc` parameters for iddiff comparison. Fixes #67 