### PR TITLE
fix: Allow github.com domain for iddiff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN echo "UPLOAD_DIR = '$PWD/tmp'" > at/config.py
 RUN echo "VERSION = '0.3.3'" >> at/config.py
 RUN echo "DT_APPAUTH_URL = 'https://datatracker.ietf.org/api/appauth/authortools'" >> at/config.py
 RUN echo "DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/doc/rfcdiff-latest-json'" >> at/config.py
-RUN echo "IDDIFF_ALLOWED_DOMAINS = ['ietf.org', 'rfc-editor.org', 'githubusercontent.com', 'github.io', 'gitlab.com']" >> at/config.py
+RUN echo "IDDIFF_ALLOWED_DOMAINS = ['ietf.org', 'rfc-editor.org', 'github.com', 'githubusercontent.com', 'github.io', 'gitlab.com']" >> at/config.py
 
 # host with waitress
 RUN pip3 install waitress


### PR DESCRIPTION
Fixes #74 