### PR TITLE
chore(deps): Update aasvg and kramdown-rfc

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,16 +3,16 @@ GEM
   specs:
     certified (1.0.0)
     json_pure (2.6.1)
-    kramdown (2.3.2)
+    kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    kramdown-rfc (1.6.6)
-      kramdown-rfc2629 (= 1.6.6)
-    kramdown-rfc2629 (1.6.6)
+    kramdown-rfc (1.6.7)
+      kramdown-rfc2629 (= 1.6.7)
+    kramdown-rfc2629 (1.6.7)
       certified (~> 1.0)
       json_pure (~> 2.0)
-      kramdown (~> 2.3.0)
+      kramdown (~> 2.4.0)
       kramdown-parser-gfm (~> 1.1)
     rexml (3.2.5)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.3.9",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "aasvg": "^0.2.0"
+        "aasvg": "^0.3.1"
       }
     },
     "node_modules/aasvg": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/aasvg/-/aasvg-0.2.0.tgz",
-      "integrity": "sha512-AcHk60uMotrSHEOluanxPFtZ/0PEVy7EvQ7Idrrblg8n4A5z5H5cOHNw2CJ/VvsmveJj+bMr68GBeQXMJRv0lQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/aasvg/-/aasvg-0.3.1.tgz",
+      "integrity": "sha512-eU4vF5xfI+ebek8LXNOFfTQHTYz1UngRQ2cpJFn/Th5Vjs5vJztXBwd5DnSIsk0DucmdV+cBvNx2eW0T/Y46qQ==",
       "bin": {
         "aasvg": "main.js"
       },
@@ -26,9 +26,9 @@
   },
   "dependencies": {
     "aasvg": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/aasvg/-/aasvg-0.2.0.tgz",
-      "integrity": "sha512-AcHk60uMotrSHEOluanxPFtZ/0PEVy7EvQ7Idrrblg8n4A5z5H5cOHNw2CJ/VvsmveJj+bMr68GBeQXMJRv0lQ=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/aasvg/-/aasvg-0.3.1.tgz",
+      "integrity": "sha512-eU4vF5xfI+ebek8LXNOFfTQHTYz1UngRQ2cpJFn/Th5Vjs5vJztXBwd5DnSIsk0DucmdV+cBvNx2eW0T/Y46qQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   },
   "homepage": "https://github.com/ietf-tools/ietf-at#readme",
   "dependencies": {
-    "aasvg": "^0.2.0"
+    "aasvg": "^0.3.1"
   }
 }


### PR DESCRIPTION
* [Bump up aasvg to 0.3.1](https://github.com/ietf-tools/ietf-at/commit/1c887ee7ca856dc7a38f095ac7b0828027228549)
* [Bump up kramdown-rfc to 1.6.7](https://github.com/ietf-tools/ietf-at/commit/171b4eaff8a38ac887ffd19ed3cd520d548792ac)