### PR TITLE
fix: Add x86_64-linux to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   kramdown-rfc


### PR DESCRIPTION
Fixes #86 