### PR TITLE
feat: Disable requirement for datatracker authentication

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ mkdir tmp
 ```
 echo "UPLOAD_DIR = '$PWD/tmp'" > at/config.py
 echo "VERSION = '9.9.9'" >> at/config.py
-echo "DT_APPAUTH_URL = 'https://datatracker.ietf.org/api/appauth/authortools'" >> at/config.py
+echo "REQUIRE_AUTH = False" >> at/config.py
 echo "DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/doc/rfcdiff-latest-json'" >> at/config.py
 echo "IDDIFF_ALLOWED_DOMAINS = ['ietf.org', 'ietf.org', 'rfc-editor.org']" >> at/config.py
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ ENV KRAMDOWN_SAFE=1
 RUN mkdir -p tmp
 RUN echo "UPLOAD_DIR = '$PWD/tmp'" > at/config.py
 RUN echo "VERSION = '0.3.12'" >> at/config.py
-RUN echo "DT_APPAUTH_URL = 'https://datatracker.ietf.org/api/appauth/authortools'" >> at/config.py
+RUN echo "REQUIRE_AUTH = False" >> at/config.py
 RUN echo "DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/doc/rfcdiff-latest-json'" >> at/config.py
 RUN echo "IDDIFF_ALLOWED_DOMAINS = ['ietf.org', 'rfc-editor.org', 'github.com', 'githubusercontent.com', 'github.io', 'gitlab.com']" >> at/config.py
 

--- a/README.md
+++ b/README.md
@@ -11,39 +11,31 @@
 docker-compose up
 ```
 
-## Obtaining API key
-
-API key can be generated from
-[IETF datatracker](https://datatracker.ietf.org/accounts/apikey/add).
-
-Select `/api/appauth/authortools` as the **Endpoint** and click **Create key**
-button.
-
 ## Testing
 
 * Test XML RFC generation
 ```
-curl localhost:8888/api/render/xml -X POST -F "apikey=datatracker_authortools_api_key" -F "file=@<xml2rfc draft (.xml) | Kramdown/mmark draft (.md, .mkd) | Text draft (.txt)>"
+curl localhost:8888/api/render/xml -X POST -F "file=@<xml2rfc draft (.xml) | Kramdown/mmark draft (.md, .mkd) | Text draft (.txt)>"
 ```
 
 * Test HTML RFC generation
 ```
-curl localhost:8888/api/render/html -X POST -F "apikey=datatracker_authortools_api_key" -F "file=@<xml2rfc draft (.xml) | Kramdown/mmark draft (.md, .mkd) | Text draft (.txt)>"
+curl localhost:8888/api/render/html -X POST -F "file=@<xml2rfc draft (.xml) | Kramdown/mmark draft (.md, .mkd) | Text draft (.txt)>"
 ```
 
 * Test text RFC generation
 ```
-curl localhost:8888/api/render/text -X POST -F "apikey=datatracker_authortools_api_key" -F "file=@<xml2rfc draft (.xml) | Kramdown/mmark draft (.md, .mkd) | Text draft (.txt)>"
+curl localhost:8888/api/render/text -X POST -F "file=@<xml2rfc draft (.xml) | Kramdown/mmark draft (.md, .mkd) | Text draft (.txt)>"
 ```
 
 * Test PDF RFC generation
 ```
-curl localhost:8888/api/render/pdf -X POST -F "apikey=datatracker_authortools_api_key" -F "file=@<xml2rfc draft (.xml) | Kramdown/mmark draft (.md, .mkd) | Text draft (.txt)>" -o draft-output.pdf
+curl localhost:8888/api/render/pdf -X POST -F "file=@<xml2rfc draft (.xml) | Kramdown/mmark draft (.md, .mkd) | Text draft (.txt)>" -o draft-output.pdf
 ```
 
 * Test validation
 ```
-curl localhost:8888/api/validate -X POST -F "apikey=datatracker_authortools_api_key" -F "file=@<xml2rfc draft (.xml) | Kramdown/mmark draft (.md, .mkd) | Text draft (.txt)>"
+curl localhost:8888/api/validate -X POST -F "file=@<xml2rfc draft (.xml) | Kramdown/mmark draft (.md, .mkd) | Text draft (.txt)>"
 ```
 
 ## Contributing

--- a/api.yml
+++ b/api.yml
@@ -12,7 +12,7 @@ components:
       type: apiKey
       in: header
       name: X-API-KEY
-      description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey).
+      description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). (optional)
 security:
   - apiKeyAuth: []
 paths:
@@ -32,7 +32,7 @@ paths:
                   description: kramdown-rfc/mmark (.md, .mkd) file or xml2rfc v2/v3 (.xml) file or text draft (.txt)
                 apikey:
                   type: string
-                  description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well.
+                  description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well. (optional)
       responses:
         '200':
           description: Returns draft in requested format.
@@ -76,7 +76,7 @@ paths:
                   description: kramdown-rfc/mmark (.md, .mkd) file or xml2rfc v2/v3 (.xml) file or text draft (.txt)
                 apikey:
                   type: string
-                  description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well.
+                  description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well. (optional)
       responses:
         '200':
           description: Returns draft in requested format.
@@ -120,7 +120,7 @@ paths:
                   description: kramdown-rfc/mmark (.md, .mkd) file or xml2rfc v2/v3 (.xml) file or text draft (.txt)
                 apikey:
                   type: string
-                  description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well.
+                  description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well. (optional)
       responses:
         '200':
           description: Returns draft in requested format.
@@ -164,7 +164,7 @@ paths:
                   description: kramdown-rfc/mmark (.md, .mkd) file or xml2rfc v2/v3 (.xml) file or text draft (.txt)
                 apikey:
                   type: string
-                  description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well.
+                  description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well. (optional)
       responses:
         '200':
           description: Returns draft in requested format.
@@ -209,7 +209,7 @@ paths:
                   description: kramdown-rfc/mmark (.md, .mkd) file or xml2rfc v2/v3 (.xml) file or text draft (.txt)
                 apikey:
                   type: string
-                  description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well.
+                  description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well. (optional)
       responses:
         '200':
           description: Returns errors, warnings and idnits output
@@ -288,7 +288,7 @@ paths:
                   description: If this property is set, HTML table is returned.
                 apikey:
                   type: string
-                  description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well.
+                  description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well. (optional)
       responses:
         '200':
           description: Returns iddiff as HTML.

--- a/at/utils/authentication.py
+++ b/at/utils/authentication.py
@@ -13,22 +13,25 @@ def require_api_key(f, *args, **kwargs):
     logger = current_app.logger
     config = current_app.config
 
-    apikey = request.headers.get('X-API-KEY')
-    if apikey is None or apikey.strip() == '':
-        if 'apikey' in request.form.keys():
-            apikey = request.form['apikey']
-        else:
-            logger.error('missing api key')
-            return jsonify(error='API key is missing'), UNAUTHORIZED
-
-    response = post(
-                config['DT_APPAUTH_URL'],
-                data={'apikey': apikey.strip()})
-
-    if response.status_code == OK and response.json()['success'] is True:
-        logger.debug('valid apikey')
+    if not config['REQUIRE_AUTH']:
+        logger.debug('Datatracker authentication is not required')
     else:
-        logger.error('invalid api key')
-        return jsonify(error='API key is invalid'), UNAUTHORIZED
+        apikey = request.headers.get('X-API-KEY')
+        if apikey is None or apikey.strip() == '':
+            if 'apikey' in request.form.keys():
+                apikey = request.form['apikey']
+            else:
+                logger.error('missing api key')
+                return jsonify(error='API key is missing'), UNAUTHORIZED
+
+        response = post(
+                    config['DT_APPAUTH_URL'],
+                    data={'apikey': apikey.strip()})
+
+        if response.status_code == OK and response.json()['success'] is True:
+            logger.debug('valid apikey')
+        else:
+            logger.error('invalid api key')
+            return jsonify(error='API key is invalid'), UNAUTHORIZED
 
     return f(*args, **kwargs)

--- a/tests/test_api_iddiff.py
+++ b/tests/test_api_iddiff.py
@@ -5,8 +5,6 @@ from shutil import rmtree
 from unittest import TestCase
 from urllib.parse import urlencode
 
-import responses
-
 from at import create_app
 
 TEST_DATA_DIR = './tests/data/'
@@ -16,7 +14,6 @@ XML_DRAFT = 'draft-smoke-signals-00.xml'
 TEST_UNSUPPORTED_FORMAT = 'draft-smoke-signals-00.odt'
 TEST_XML_ERROR = 'draft-smoke-signals-00.error.xml'
 TEMPORARY_DATA_DIR = './tests/tmp/'
-DT_APPAUTH_URL = 'https://example.com/'
 DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/doc/rfcdiff-latest-json'
 VALID_API_KEY = 'foobar'
 ALLOWED_URLS = [
@@ -42,22 +39,9 @@ class TestApiIddiff(TestCase):
 
         config = {
                 'UPLOAD_DIR': abspath(TEMPORARY_DATA_DIR),
-                'DT_APPAUTH_URL': DT_APPAUTH_URL,
+                'REQUIRE_AUTH': False,
                 'DT_LATEST_DRAFT_URL': DT_LATEST_DRAFT_URL,
                 'IDDIFF_ALLOWED_DOMAINS': IDDIFF_ALLOWED_DOMAINS}
-
-        # mock datatracker api response
-        self.responses = responses.RequestsMock()
-        self.responses.start()
-        self.responses.add(
-                responses.POST,
-                DT_APPAUTH_URL,
-                json={'success': True},
-                status=200)
-        for url in ALLOWED_URLS:
-            self.responses.add_passthru(url)
-        self.addCleanup(self.responses.stop)
-        self.addCleanup(self.responses.reset)
 
         self.app = create_app(config)
 

--- a/tests/test_api_render.py
+++ b/tests/test_api_render.py
@@ -4,8 +4,6 @@ from pathlib import Path
 from shutil import rmtree
 from unittest import TestCase
 
-import responses
-
 from at import create_app
 
 TEST_DATA_DIR = './tests/data/'
@@ -22,7 +20,6 @@ TEST_DATA = [
         TEST_XML_DRAFT, TEST_XML_V2_DRAFT, TEST_TEXT_DRAFT,
         TEST_KRAMDOWN_DRAFT, TEST_MMARK_DRAFT]
 TEMPORARY_DATA_DIR = './tests/tmp/'
-DT_APPAUTH_URL = 'https://example.com/'
 VALID_API_KEY = 'foobar'
 
 
@@ -42,18 +39,7 @@ class TestApiRender(TestCase):
 
         config = {
                 'UPLOAD_DIR': abspath(TEMPORARY_DATA_DIR),
-                'DT_APPAUTH_URL': DT_APPAUTH_URL}
-
-        # mock datatracker api response
-        self.responses = responses.RequestsMock()
-        self.responses.start()
-        self.responses.add(
-                responses.POST,
-                DT_APPAUTH_URL,
-                json={'success': True},
-                status=200)
-        self.addCleanup(self.responses.stop)
-        self.addCleanup(self.responses.reset)
+                'REQUIRE_AUTH': False}
 
         self.app = create_app(config)
 

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -4,8 +4,6 @@ from pathlib import Path
 from shutil import rmtree
 from unittest import TestCase
 
-import responses
-
 from at import create_app
 
 TEST_DATA_DIR = './tests/data/'
@@ -23,7 +21,6 @@ TEST_DATA = [
         TEST_XML_DRAFT, TEST_XML_V2_DRAFT, TEST_TEXT_DRAFT,
         TEST_KRAMDOWN_DRAFT, TEST_MMARK_DRAFT]
 TEMPORARY_DATA_DIR = './tests/tmp/'
-DT_APPAUTH_URL = 'https://example.com/'
 VALID_API_KEY = 'foobar'
 
 
@@ -43,18 +40,7 @@ class TestApiValidate(TestCase):
 
         config = {
                 'UPLOAD_DIR': abspath(TEMPORARY_DATA_DIR),
-                'DT_APPAUTH_URL': DT_APPAUTH_URL}
-
-        # mock datatracker api response
-        self.responses = responses.RequestsMock()
-        self.responses.start()
-        self.responses.add(
-                responses.POST,
-                DT_APPAUTH_URL,
-                json={'success': True},
-                status=200)
-        self.addCleanup(self.responses.stop)
-        self.addCleanup(self.responses.reset)
+                'REQUIRE_AUTH': False}
 
         self.app = create_app(config)
 

--- a/tests/test_api_version.py
+++ b/tests/test_api_version.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 from at import create_app
 
 AUTHOR_TOOLS_API_TEST_VERSION = '0.0.1'
-DT_APPAUTH_URL = 'https://example.com/'
 VERSION_LABELS = (
     'author_tools_api',
     'xml2rfc',
@@ -25,7 +24,7 @@ class TestApiVersion(TestCase):
         set_logger(CRITICAL)
 
         config = {
-                'DT_APPAUTH_URL': DT_APPAUTH_URL,
+                'REQUIRE_AUTH': False,
                 'VERSION': AUTHOR_TOOLS_API_TEST_VERSION}
 
         self.app = create_app(config)

--- a/tests/test_utils_authentication.py
+++ b/tests/test_utils_authentication.py
@@ -35,6 +35,7 @@ class TestUtilsAuthentication(TestCase):
         config = {
                 'UPLOAD_DIR': abspath(TEMPORARY_DATA_DIR),
                 'DT_APPAUTH_URL': DT_APPAUTH_URL,
+                'REQUIRE_AUTH': True,
                 'VERSION': AUTHOR_TOOLS_API_TEST_VERSION}
 
         self.app = create_app(config)
@@ -140,3 +141,21 @@ class TestUtilsAuthentication(TestCase):
 
                 self.assertEqual(result.status_code, 401)
                 self.assertEqual(json_data['error'], 'API key is invalid')
+
+    def test_authentication_disabled(self):
+        config = {
+                'UPLOAD_DIR': abspath(TEMPORARY_DATA_DIR),
+                'REQUIRE_AUTH': False,
+                'VERSION': AUTHOR_TOOLS_API_TEST_VERSION}
+
+        app = create_app(config)
+        with app.test_client() as client:
+            with app.app_context():
+                filename = get_path(TEST_XML_DRAFT)
+                result = client.post(
+                            '/api/render/xml',
+                            data={
+                                'file': (open(filename, 'rb'), filename),
+                                'apikey': VALID_API_KEY})
+
+                self.assertEqual(result.status_code, 200)


### PR DESCRIPTION
Datatracker authentication can be enabled or disabled by changing the
configuration option `REQUIRE_AUTH` to `True` or `False`.

Fixes #103 