### PR TITLE
fix: Revert citation library change for kramdown-rfc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,9 +59,6 @@ RUN rm roboto-mono.zip
 # Disable local file read for kramdown-rfc
 ENV KRAMDOWN_SAFE=1
 
-# Set default XML resource host for kramdown-rfc
-ENV XML_RESOURCE_ORG_HOST=bib.ietf.org
-
 # Install waitress
 RUN pip3 install waitress
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,9 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    kramdown-rfc (1.6.13)
-      kramdown-rfc2629 (= 1.6.13)
-    kramdown-rfc2629 (1.6.13)
+    kramdown-rfc (1.6.14)
+      kramdown-rfc2629 (= 1.6.14)
+    kramdown-rfc2629 (1.6.14)
       certified (~> 1.0)
       json_pure (~> 2.0)
       kramdown (~> 2.4.0)


### PR DESCRIPTION
Changes citation libarary to tools.ietf.org