### PR TITLE
feat: Send rendering errors and warnings

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 source=at
-omit = tests/*, at/__init__.py
+omit = tests/*, at/__init__.py, at/config.py
 
 [report]
 show_missing = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ echo "ALLOWED_DOMAINS = ['ietf.org', 'ietf.org', 'rfc-editor.org']" >> at/config
 
 * Run flask server.
 ```
-FLASK_APP=at FLASK_ENV=development flask run
+SITE_URL='http://localhost:5000' PATH=$PATH:./node_modules/.bin/ FLASK_APP=at FLASK_DEBUG=True flask run
 ```
 
 ## Running tests
@@ -90,5 +90,5 @@ pip install -r requirements.dev.txt
 
 * Run unit tests.
 ```
-python -m unittest discover tests
+PATH=$PATH:./node_modules/.bin/ python -m unittest discover tests
 ```

--- a/api.yml
+++ b/api.yml
@@ -18,7 +18,7 @@ security:
 paths:
   /api/render/text:
     post:
-      summary: Returns rendered draft in text format.
+      summary: Convert draft to text format.
       requestBody:
         required: true
         content:
@@ -35,11 +35,27 @@ paths:
                   description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well. (optional)
       responses:
         '200':
-          description: Returns draft in requested format.
+          description: Returns temporary URL to the draft in requested format.
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    description: list of errors
+                    items:
+                      type: string
+                      description: error description
+                  warnings:
+                    type: array
+                    description: list of warnings
+                    items:
+                      type: string
+                      description: warning description
+                  url:
+                    type: string
+                    description: Temporary URL to requested format
         '400':
           description: Error has occured.
           content:
@@ -62,7 +78,7 @@ paths:
                     description: Error description
   /api/render/xml:
     post:
-      summary: Returns rendered draft in xml2rfc v3 format.
+      summary: Convert draft to xml2rfc v3 format.
       requestBody:
         required: true
         content:
@@ -79,11 +95,27 @@ paths:
                   description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well. (optional)
       responses:
         '200':
-          description: Returns draft in requested format.
+          description: Returns temporary URL to the draft in requested format.
           content:
-            application/xml:
+            application/json:
               schema:
-                type: string
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    description: list of errors
+                    items:
+                      type: string
+                      description: error description
+                  warnings:
+                    type: array
+                    description: list of warnings
+                    items:
+                      type: string
+                      description: warning description
+                  url:
+                    type: string
+                    description: Temporary URL to requested format
         '400':
           description: Error has occured.
           content:
@@ -106,7 +138,7 @@ paths:
                     description: Error description
   /api/render/html:
     post:
-      summary: Returns rendered draft in HTML format.
+      summary: Convert draft to HTML format.
       requestBody:
         required: true
         content:
@@ -123,11 +155,27 @@ paths:
                   description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well. (optional)
       responses:
         '200':
-          description: Returns draft in requested format.
+          description: Returns temporary URL to the draft in requested format.
           content:
-            text/html:
+            application/json:
               schema:
-                type: string
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    description: list of errors
+                    items:
+                      type: string
+                      description: error description
+                  warnings:
+                    type: array
+                    description: list of warnings
+                    items:
+                      type: string
+                      description: warning description
+                  url:
+                    type: string
+                    description: Temporary URL to requested format
         '400':
           description: Error has occured.
           content:
@@ -150,7 +198,7 @@ paths:
                     description: Error description
   /api/render/pdf:
     post:
-      summary: Returns rendered draft in PDF format.
+      summary: Renders draft to PDF format.
       requestBody:
         required: true
         content:
@@ -167,12 +215,27 @@ paths:
                   description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well. (optional)
       responses:
         '200':
-          description: Returns draft in requested format.
+          description: Returns temporary URL to the draft in requested format.
           content:
-            application/pdf:
+            application/json:
               schema:
-                type: string
-                format: binary
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    description: list of errors
+                    items:
+                      type: string
+                      description: error description
+                  warnings:
+                    type: array
+                    description: list of warnings
+                    items:
+                      type: string
+                      description: warning description
+                  url:
+                    type: string
+                    description: Temporary URL to requested format
         '400':
           description: Error has occured.
           content:

--- a/at/__init__.py
+++ b/at/__init__.py
@@ -23,6 +23,15 @@ def create_app(config=None):
 
     SENTRY_DSN = getenv('SENTRY_DSN')
 
+    if site_url := getenv('SITE_URL'):
+        app.logger.info('Using SITE_URL from ENV.')
+        app.config['SITE_URL'] = site_url
+    elif 'SITE_URL' not in app.config.keys():
+        app.logger.info('SITE_URL not set. Using default.')
+        app.config['SITE_URL'] = 'http://localhost'
+
+    app.logger.info('SITE_URL: {}'.format(app.config['SITE_URL']))
+
     if SENTRY_DSN:
         sentry_init(
                 dsn=SENTRY_DSN,

--- a/at/api.py
+++ b/at/api.py
@@ -8,6 +8,7 @@ from at.utils.file import (
         allowed_file, get_file, get_name, get_name_with_revision,
         save_file, save_file_from_text, DownloadError)
 from at.utils.iddiff import get_id_diff, IddiffError
+from at.utils.logs import update_logs
 from at.utils.net import (
         is_valid_url, get_latest, InvalidURL, LatestDraftNotFound)
 from at.utils.processor import (
@@ -42,6 +43,8 @@ def render(format):
 
     file = request.files['file']
 
+    logs = {'errors': [], 'warnings': []}
+
     if file.filename == '':
         logger.info('filename missing')
         return jsonify(error='Filename is missing'), BAD_REQUEST
@@ -62,7 +65,8 @@ def render(format):
             return jsonify(error='id2xml error: {}'.format(e)), BAD_REQUEST
 
         try:
-            xml_file = get_xml(filename, logger=logger)
+            xml_file, _logs = get_xml(filename, logger=logger)
+            logs = update_logs(logs, _logs)
         except XML2RFCError as e:
             return jsonify(error='xml2rfc error: {}'.format(e)), BAD_REQUEST
 
@@ -72,13 +76,16 @@ def render(format):
             if format == 'xml':
                 rendered_filename = get_file(xml_file)
             elif format == 'html':
-                html_file = get_html(xml_file, logger=logger)
+                html_file, _logs = get_html(xml_file, logger=logger)
+                logs = update_logs(logs, _logs)
                 rendered_filename = get_file(html_file)
             elif format == 'text':
-                text_file = get_text(xml_file, logger=logger)
+                text_file, _logs = get_text(xml_file, logger=logger)
+                logs = update_logs(logs, _logs)
                 rendered_filename = get_file(text_file)
             elif format == 'pdf':
-                pdf_file = get_pdf(xml_file, logger=logger)
+                pdf_file, _logs = get_pdf(xml_file, logger=logger)
+                logs = update_logs(logs, _logs)
                 rendered_filename = get_file(pdf_file)
             else:
                 logger.info(
@@ -88,13 +95,31 @@ def render(format):
         except XML2RFCError as e:
             return jsonify(error='xml2rfc error: {}'.format(e)), BAD_REQUEST
 
-        return send_from_directory(
-                dir_path,
-                get_file(rendered_filename),
-                as_attachment=True)
+        if len(rendered_filename) > 0:
+            url = '/'.join((current_app.config['SITE_URL'],
+                            'api',
+                            'export',
+                            rendered_filename))
+
+        return jsonify(
+                    url=url,
+                    logs=logs)
     else:
         logger.info('File format not supportted: {}'.format(file.filename))
         return jsonify(error='Input file format not supported'), BAD_REQUEST
+
+
+@bp.route('/export/<dir>/<file>', methods=('GET',))
+@require_api_key
+def export(dir, file):
+    dir = dir.replace('.', '')
+    dir = dir.replace('/', '')
+    file = file.replace('/', '')
+    dir_path = '/'.join((current_app.config['UPLOAD_DIR'], dir))
+    return send_from_directory(
+                dir_path,
+                get_file(file),
+                as_attachment=True)
 
 
 @bp.route('/validate', methods=('POST',))

--- a/at/utils/file.py
+++ b/at/utils/file.py
@@ -48,9 +48,9 @@ def get_filename(filename, ext):
 
 
 def get_file(filename):
-    '''Returns the filename part from a file path'''
+    '''Returns the filename and the parent directory'''
 
-    return filename.split('/')[-1]
+    return '/'.join(filename.split('/')[-2:])
 
 
 def save_file(file, upload_dir):

--- a/at/utils/logs.py
+++ b/at/utils/logs.py
@@ -1,7 +1,7 @@
 from re import compile as re_compile, IGNORECASE
 
-XML2RFC_ERROR_REGEX = re_compile(r'^.* Error: (?P<message>.*)$', IGNORECASE)
-XML2RFC_WARN_REGEX = re_compile(r'^.* Warning: (?P<message>.*)$', IGNORECASE)
+XML2RFC_ERROR_REGEX = re_compile(r'^.*Error: (?P<message>.*)$', IGNORECASE)
+XML2RFC_WARN_REGEX = re_compile(r'^.*Warning: (?P<message>.*)$', IGNORECASE)
 
 
 def process_xml2rfc_log(output):
@@ -10,10 +10,8 @@ def process_xml2rfc_log(output):
     errors = []
     warnings = []
 
-    if output.stdout:
-        log += output.stdout.decode('utf-8', errors='ignore').split('\n')
     if output.stderr:
-        log += output.stderr.decode('utf-8', errors='ignore').split('\n')
+        log = output.stderr.decode('utf-8', errors='ignore').split('\n')
 
     for line in log:
         error = XML2RFC_ERROR_REGEX.search(line)
@@ -35,3 +33,12 @@ def get_errors(output):
         return '\n'.join(log['errors'])
     else:
         return None
+
+
+def update_logs(logs, new_entries):
+    '''Adds new entries to logs'''
+    if new_entries:
+        logs['errors'].extend(new_entries['errors'])
+        logs['warnings'].extend(new_entries['warnings'])
+
+    return logs

--- a/at/utils/processor.py
+++ b/at/utils/processor.py
@@ -6,7 +6,7 @@ from xml2rfc.parser import XmlRfcError
 from lxml.etree import XMLSyntaxError
 
 from at.utils.file import get_extension, get_filename, save_file
-from at.utils.logs import get_errors
+from at.utils.logs import get_errors, process_xml2rfc_log
 
 
 # Exceptions
@@ -158,13 +158,17 @@ def convert_v2v3(filename, logger=getLogger()):
             logger.info('xml2rfc v2v3 error: no error output')
         raise XML2RFCError(errors)
 
+    logs = process_xml2rfc_log(output)
+
     logger.info('new file saved at {}'.format(xml_file))
-    return xml_file
+    return (xml_file, logs)
 
 
 def get_xml(filename, logger=getLogger()):
     '''Convert/parse XML to XML2RFC v3
     NOTE: if file is XML2RFC v2 that will get converted to v3'''
+
+    logs = None
 
     try:
         logger.debug('invoking xml2rfc parser')
@@ -175,13 +179,13 @@ def get_xml(filename, logger=getLogger()):
         xml2rfc_version = xmlroot.get('version', '2')
 
         if xml2rfc_version == '2':
-            filename = convert_v2v3(filename, logger)
+            filename, logs = convert_v2v3(filename, logger)
     except (XmlRfcError, XMLSyntaxError) as e:
         logger.info('xml2rfc error: {}'.format(str(e)))
         raise XML2RFCError(e)
 
     logger.info('new file saved at {}'.format(filename))
-    return filename
+    return (filename, logs)
 
 
 def get_html(filename, logger=getLogger()):
@@ -208,12 +212,10 @@ def get_html(filename, logger=getLogger()):
         raise XML2RFCError(errors)
 
     logger.info('new file saved at {}'.format(html_file))
-    return html_file
+    return (html_file, process_xml2rfc_log(output))
 
 
 def get_text(filename, logger=getLogger()):
-    '''Render text'''
-    logger.debug('running xml2rfc text converter')
 
     text_file = get_filename(filename, 'txt')
 
@@ -235,7 +237,7 @@ def get_text(filename, logger=getLogger()):
         raise XML2RFCError(errors)
 
     logger.info('new file saved at {}'.format(text_file))
-    return text_file
+    return (text_file, process_xml2rfc_log(output))
 
 
 def get_pdf(filename, logger=getLogger()):
@@ -262,4 +264,4 @@ def get_pdf(filename, logger=getLogger()):
         raise XML2RFCError(errors)
 
     logger.info('new file saved at {}'.format(pdf_file))
-    return pdf_file
+    return (pdf_file, process_xml2rfc_log(output))

--- a/at/utils/text.py
+++ b/at/utils/text.py
@@ -37,8 +37,8 @@ def get_text_id(dir_path, filename, logger=getLogger()):
         try:
             if file_ext.lower() in ['.md', '.mkd']:
                 filename = md2xml(filename, logger)
-            xml_file = get_xml(filename, logger=logger)
-            filename = get_text(xml_file, logger=logger)
+            xml_file, _ = get_xml(filename, logger=logger)
+            filename, _ = get_text(xml_file, logger=logger)
         except (KramdownError, MmarkError, XML2RFCError) as e:
             logger.error(
                     'error processing non text file: {}'.format(filename))

--- a/tests/test_utils_file.py
+++ b/tests/test_utils_file.py
@@ -80,11 +80,12 @@ class TestUtilsFile(TestCase):
 
     def test_get_file(self):
         for extension in ALLOWED_EXTENSIONS:
-            file_path = self.faker.file_path(extension=extension)
+            file_path = self.faker.file_path(extension=extension, depth=3)
             result = get_file(file_path)
 
             self.assertTrue(result.endswith(extension))
-            self.assertNotIn('/', result)
+            self.assertFalse(result.startswith('/'))
+            self.assertTrue(result.count('/'), 1)
 
     def test_save_file(self):
         for filename in TEST_DATA:

--- a/tests/test_utils_logs.py
+++ b/tests/test_utils_logs.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from shutil import copy, rmtree
 from unittest import TestCase
 
-from at.utils.logs import process_xml2rfc_log, get_errors
+from at.utils.logs import get_errors, process_xml2rfc_log, update_logs
 from at.utils.validation import xml2rfc_validation
 
 TEST_DATA_DIR = './tests/data/'
@@ -65,3 +65,24 @@ class TestUtilsLogs(TestCase):
         self.assertIsNotNone(errors)
         self.assertIsInstance(errors, str)
         self.assertGreater(len(errors), 0)
+
+    def test_update_logs(self):
+        logs = {
+                'errors': ['foo', ],
+                'warnings': ['bar', ]}
+
+        new_entries = {
+                'errors': ['foobar_error', 'foobar_error_1', ],
+                'warnings': ['foobar_warning', 'foobar_warning_1', ]}
+
+        updated_logs = update_logs(logs, new_entries)
+
+        for (key, entries) in logs.items():
+            self.assertIn(key, updated_logs.keys())
+            for entry in entries:
+                self.assertIn(entry, updated_logs[key])
+
+        for (key, entries) in new_entries.items():
+            self.assertIn(key, updated_logs.keys())
+            for entry in entries:
+                self.assertIn(entry, updated_logs[key])

--- a/tests/test_utils_processor.py
+++ b/tests/test_utils_processor.py
@@ -86,37 +86,54 @@ class TestUtilsProcessor(TestCase):
         self.assertEqual(Path(saved_file).suffix, '.xml')
 
     def test_convert_v2v3(self):
-        saved_file = convert_v2v3(
+        saved_file, logs = convert_v2v3(
                 ''.join([TEMPORARY_DATA_DIR, TEST_XML_V2_DRAFT]))
 
         self.assertTrue(Path(saved_file).exists())
         self.assertEqual(Path(saved_file).suffix, '.xml')
+        self.assertIn('errors', logs.keys())
+        self.assertIn('warnings', logs.keys())
 
     def test_get_xml(self):
-        for file in [TEST_XML_DRAFT, TEST_XML_V2_DRAFT]:
-            saved_file = get_xml(
-                    ''.join([TEMPORARY_DATA_DIR, file]))
+        saved_file, logs = get_xml(
+                ''.join([TEMPORARY_DATA_DIR, TEST_XML_V2_DRAFT]))
 
-            self.assertTrue(Path(saved_file).exists())
-            self.assertEqual(Path(saved_file).suffix, '.xml')
+        self.assertTrue(Path(saved_file).exists())
+        self.assertEqual(Path(saved_file).suffix, '.xml')
+        self.assertIn('errors', logs.keys())
+        self.assertIn('warnings', logs.keys())
+
+    def test_get_xml_v3(self):
+        saved_file, logs = get_xml(
+                ''.join([TEMPORARY_DATA_DIR, TEST_XML_DRAFT]))
+
+        self.assertTrue(Path(saved_file).exists())
+        self.assertEqual(Path(saved_file).suffix, '.xml')
+        self.assertIsNone(logs)
 
     def test_get_html(self):
-        saved_file = get_html(
+        saved_file, logs = get_html(
                 ''.join([TEMPORARY_DATA_DIR, TEST_XML_DRAFT]))
 
         self.assertTrue(Path(saved_file).exists())
         self.assertEqual(Path(saved_file).suffix, '.html')
+        self.assertIn('errors', logs.keys())
+        self.assertIn('warnings', logs.keys())
 
     def test_get_text(self):
-        saved_file = get_text(
+        saved_file, logs = get_text(
                 ''.join([TEMPORARY_DATA_DIR, TEST_XML_DRAFT]))
 
         self.assertTrue(Path(saved_file).exists())
         self.assertEqual(Path(saved_file).suffix, '.txt')
+        self.assertIn('errors', logs.keys())
+        self.assertIn('warnings', logs.keys())
 
     def test_get_pdf(self):
-        saved_file = get_pdf(
+        saved_file, logs = get_pdf(
                 ''.join([TEMPORARY_DATA_DIR, TEST_XML_DRAFT]))
 
         self.assertTrue(Path(saved_file).exists())
         self.assertEqual(Path(saved_file).suffix, '.pdf')
+        self.assertIn('errors', logs.keys())
+        self.assertIn('warnings', logs.keys())


### PR DESCRIPTION
With this change API returns a temporary URL to the generated file, along with errors and warnings.