### PR TITLE
feat: Introduce new property lastet to /api/iddiff

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -358,6 +358,9 @@ paths:
                 table:
                   type: string
                   description: If this property is set, HTML table is returned. (ignored if wdiff is set)
+                latest:
+                  type: string
+                  description: If this property is set and second document is not provided, use the latest document from datatracker for comparison.
                 url1:
                   type: string
                   description: (rfcdiff compatibility parameter) First draft URL or document name.

--- a/at/api.py
+++ b/at/api.py
@@ -269,6 +269,7 @@ def id_diff():
     doc_2 = request.values.get('doc_2', '').strip()
     url_1 = request.values.get('url_1', '').strip()
     url_2 = request.values.get('url_2', '').strip()
+    latest = request.values.get('latest', '').strip()
 
     if request.values.get('table', False):
         table = True
@@ -394,10 +395,16 @@ def id_diff():
                         BAD_REQUEST)
             else:
                 try:
-                    url = get_previous(
-                            original_doc_name,
-                            current_app.config['DT_LATEST_DRAFT_URL'],
-                            logger)
+                    if latest:
+                        url = get_latest(
+                                draft_name,
+                                current_app.config['DT_LATEST_DRAFT_URL'],
+                                logger)
+                    else:
+                        url = get_previous(
+                                original_doc_name,
+                                current_app.config['DT_LATEST_DRAFT_URL'],
+                                logger)
                     dir_path_2, filename_2 = get_text_id_from_url(
                                             url,
                                             current_app.config['UPLOAD_DIR'],

--- a/tests/test_api_iddiff.py
+++ b/tests/test_api_iddiff.py
@@ -753,3 +753,18 @@ class TestApiIddiff(TestCase):
                 self.assertEqual(result.status_code, 400)
                 msg = 'Can not determine draft/rfc'
                 self.assertEqual(json_data['error'], msg)
+
+    def test_iddiff_with_latest(self):
+        with self.app.test_client() as client:
+            with self.app.app_context():
+                id = 'draft-ietf-quic-http'
+                result = client.post(
+                        '/api/iddiff',
+                        data={
+                            'doc_1': id,
+                            'latest': True,
+                            'apikey': VALID_API_KEY})
+
+                data = result.get_data()
+                self.assertEqual(result.status_code, 200)
+                self.assertIn(b'<html lang="en">', data)


### PR DESCRIPTION
When `latest` property is set use the latest document in the series from datataracker for comparison.

Fixes #251 