### PR TITLE
fix: Handle cases where filename can not be determined

### DIFF
--- a/at/utils/file.py
+++ b/at/utils/file.py
@@ -89,9 +89,14 @@ def save_file_from_url(url, upload_dir, logger=getLogger()):
     '''Download and save the file from given URL and returns path'''
     dir_path = path.join(upload_dir, str(uuid4()))
     mkdir(dir_path, mode=DIR_MODE)
+    save_filename = secure_filename(url.split('/')[-1])
+    if len(save_filename) == 0:
+        error = 'Can not determine the filename: {}'.format(url)
+        logger.error(error)
+        raise DownloadError(error)
     filename = path.join(
             dir_path,
-            secure_filename(url.split('/')[-1]))
+            save_filename)
 
     try:
         response = get(url)

--- a/tests/test_api_iddiff.py
+++ b/tests/test_api_iddiff.py
@@ -940,3 +940,15 @@ class TestApiIddiff(TestCase):
                 self.assertEqual(result.status_code, 400)
                 self.assertTrue(json_data['error'].startswith(
                                     'Error converting second document'))
+
+    def test_iddiff_filename_error(self):
+        with self.app.test_client() as client:
+            with self.app.app_context():
+                result = client.post(
+                        '/api/iddiff',
+                        data={'url_1': 'https://ietf.org/'})
+                json_data = result.get_json()
+
+                self.assertEqual(result.status_code, 400)
+                self.assertTrue(json_data['error'].startswith(
+                                    'Can not determine the filename:'))

--- a/tests/test_utils_file.py
+++ b/tests/test_utils_file.py
@@ -120,6 +120,13 @@ class TestUtilsFile(TestCase):
         self.assertEqual(str(error.exception),
                          'Error occured while downloading file.')
 
+    def test_save_file_from_url_no_filename(self):
+        url = 'https://example.com/'
+        with self.assertRaises(DownloadError) as error:
+            save_file_from_url(url, TEMPORARY_DATA_DIR)
+        self.assertEqual(str(error.exception),
+                         'Can not determine the filename: {}'.format(url))
+
     def test_save_file_from_url_valid(self):
         id_url = 'https://www.ietf.org/archive/id/draft-ietf-quic-http-23.txt'
         (dir_path, file_path) = save_file_from_url(id_url, TEMPORARY_DATA_DIR)


### PR DESCRIPTION
This fix handles cases where the filename can not be determined in downloaded files for iddiff.

Fixes #267