### PR TITLE
chore: Update latest draft API URL for datatracker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN mkdir -p tmp && \
     echo "UPLOAD_DIR = '$PWD/tmp'" > at/config.py && \
     echo "VERSION = '0.12.12'" >> at/config.py && \
     echo "REQUIRE_AUTH = False" >> at/config.py && \
-    echo "DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/doc/rfcdiff-latest-json'" >> at/config.py && \
+    echo "DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/api/rfcdiff-latest-json'" >> at/config.py && \
     echo "ALLOWED_DOMAINS = ['ietf.org', 'rfc-editor.org', 'github.com', 'githubusercontent.com', 'github.io', 'gitlab.com']" >> at/config.py
 
 # host with waitress

--- a/tests/test_api_abnf_extract.py
+++ b/tests/test_api_abnf_extract.py
@@ -9,7 +9,7 @@ from at import create_app
 
 API = '/api/abnf/extract'
 TEMPORARY_DATA_DIR = './tests/tmp/'
-DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/doc/rfcdiff-latest-json'
+DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/api/rfcdiff-latest-json'
 ALLOWED_DOMAINS = ['ietf.org', 'rfc-editor.org']
 
 

--- a/tests/test_api_iddiff.py
+++ b/tests/test_api_iddiff.py
@@ -16,7 +16,7 @@ XML_DRAFT = 'draft-smoke-signals-00.xml'
 TEST_UNSUPPORTED_FORMAT = 'draft-smoke-signals-00.odt'
 TEST_XML_ERROR = 'draft-smoke-signals-00.error.xml'
 TEMPORARY_DATA_DIR = './tests/tmp/'
-DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/doc/rfcdiff-latest-json'
+DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/api/rfcdiff-latest-json'
 VALID_API_KEY = 'foobar'
 ALLOWED_DOMAINS = ['ietf.org', ]
 

--- a/tests/test_utils_net.py
+++ b/tests/test_utils_net.py
@@ -7,7 +7,7 @@ from at.utils.net import (
         get_latest, get_previous, is_valid_url, is_url, InvalidURL,
         DocumentNotFound)
 
-DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/doc/rfcdiff-latest-json'
+DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/api/rfcdiff-latest-json'
 
 
 class TestUtilsNet(TestCase):


### PR DESCRIPTION
Change the URL to https://datatracker.ietf.org/api/rfcdiff-latest-json/