### PR TITLE
fix: iddiff timeout

### DIFF
--- a/at/utils/iddiff.py
+++ b/at/utils/iddiff.py
@@ -1,9 +1,10 @@
 from logging import getLogger
-from subprocess import run as proc_run, CalledProcessError
+from subprocess import run as proc_run, CalledProcessError, TimeoutExpired
 
 
 OK = 200
 ALLOWED_SCHEMES = ['http', 'https']
+TIMEOUT = 20  # in seconds
 
 
 # Exceptions
@@ -23,26 +24,41 @@ def get_id_diff(old_draft, new_draft, diff_tool='iddiff', table=False,
         logger.debug('running iddiff')
         diff = ['iddiff', ]
 
-    if wdiff:
-        output = proc_run(args=diff + ['--hwdiff', old_draft, new_draft],
-                          capture_output=True)
-    elif chbars:
-        output = proc_run(args=diff + ['--chbars', old_draft, new_draft],
-                          capture_output=True)
-    elif abdiff:
-        output = proc_run(args=diff + ['--abdiff', old_draft, new_draft],
-                          capture_output=True)
-    elif table and diff_tool == 'iddiff':
-        output = proc_run(args=diff + ['-t', old_draft, new_draft],
-                          capture_output=True)
-    else:
-        output = proc_run(args=diff + [old_draft, new_draft],
-                          capture_output=True)
+    try:
+        if wdiff:
+            output = proc_run(args=diff + ['--hwdiff', old_draft, new_draft],
+                              timeout=TIMEOUT,
+                              capture_output=True)
+        elif chbars:
+            output = proc_run(args=diff + ['--chbars', old_draft, new_draft],
+                              timeout=TIMEOUT,
+                              capture_output=True)
+        elif abdiff:
+            output = proc_run(args=diff + ['--abdiff', old_draft, new_draft],
+                              timeout=TIMEOUT,
+                              capture_output=True)
+        elif table and diff_tool == 'iddiff':
+            output = proc_run(args=diff + ['-t', old_draft, new_draft],
+                              timeout=TIMEOUT,
+                              capture_output=True)
+        else:
+            output = proc_run(args=diff + [old_draft, new_draft],
+                              timeout=TIMEOUT,
+                              capture_output=True)
+    except TimeoutExpired:
+        if diff_tool == 'rfcdiff':
+            logger.info('iddiff error: Timeout error.')
+            raise IddiffError('Timeout while running comparison.')
+        else:
+            # try again with rfcdiff
+            return get_id_diff(old_draft, new_draft, diff_tool='rfcdiff',
+                               table=table, wdiff=wdiff, chbars=chbars,
+                               abdiff=abdiff, logger=logger)
 
     try:
         output.check_returncode()
     except CalledProcessError:
-        logger.info('iddiff error: {}:'.format(output.stderr.decode('utf-8')))
+        logger.info('iddiff error: {}'.format(output.stderr.decode('utf-8')))
         raise IddiffError(output.stderr.decode('utf-8'))
 
     return output.stdout.decode('utf-8')

--- a/tests/test_api_iddiff.py
+++ b/tests/test_api_iddiff.py
@@ -952,7 +952,7 @@ class TestApiIddiff(TestCase):
 
                 data = result.get_data()
                 self.assertEqual(result.status_code, 200)
-                self.assertIn(b'<html lang="en">', data)
+                self.assertIn(b'<html', data)
 
     def test_iddiff_text_processing_first_doc(self):
         with self.app.test_client() as client:

--- a/tests/test_utils_iddiff.py
+++ b/tests/test_utils_iddiff.py
@@ -1,5 +1,7 @@
 from logging import disable as set_logger, INFO, CRITICAL
 from unittest import TestCase
+from unittest.mock import patch
+
 
 from at.utils.iddiff import get_id_diff, IddiffError
 
@@ -74,3 +76,9 @@ class TestUtilsIddiff(TestCase):
 
         self.assertIn('OLD:', id_diff)
         self.assertIn('NEW:', id_diff)
+
+    @patch('at.utils.iddiff.TIMEOUT', 0)
+    def test_iddiff_timeout(self):
+        with self.assertRaises(IddiffError):
+            get_id_diff(''.join([TEST_DATA_DIR, DRAFT_A]),
+                        ''.join([TEST_DATA_DIR, DRAFT_B]))


### PR DESCRIPTION
This change introduces 20 seconds timeout for rfcdiff and iddiff operations.

if iddiff operation takes more than 20 seconds, author tools will try to use rfcdiff.

if rfcdiff operation takes more than 20 seconds, a timeout error will be returned.