### PR TITLE
feat: Allow comparing files as it is

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -376,6 +376,9 @@ paths:
                 iddiff:
                   type: string
                   description: Use iddiff instead of iddiff (experimental)
+                raw:
+                  type: string
+                  description: If this property is set, input files are not converted to text.
                 apikey:
                   type: string
                   description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well. (optional)
@@ -455,6 +458,11 @@ paths:
           schema:
             type: string
           description: Use iddiff instead of iddiff (experimental)
+        - in: query
+          name: raw
+          schema:
+            type: string
+          description: If this property is set, input files are not converted to text.
         - in: query
           name: url1
           schema:

--- a/at/api.py
+++ b/at/api.py
@@ -192,7 +192,8 @@ def idnits():
         try:
             _, filename = get_text_id_from_file(
                     file=file,
-                    upload_dir=current_app.config['UPLOAD_DIR'])
+                    upload_dir=current_app.config['UPLOAD_DIR'],
+                    logger=logger)
         except TextProcessingError as e:
             return jsonify(error=str(e)), BAD_REQUEST
     else:
@@ -207,7 +208,7 @@ def idnits():
                 _, filename = get_text_id_from_url(
                                             url,
                                             current_app.config['UPLOAD_DIR'],
-                                            logger)
+                                            logger=logger)
         except TextProcessingError as e:
             return jsonify(error=str(e)), BAD_REQUEST
         except InvalidURL as e:
@@ -243,6 +244,11 @@ def id_diff():
     url_1 = request.values.get('url_1', '').strip()
     url_2 = request.values.get('url_2', '').strip()
     latest = request.values.get('latest', '').strip()
+
+    if request.values.get('raw', False):
+        raw = True
+    else:
+        raw = False
 
     if request.values.get('table', False):
         table = True
@@ -328,7 +334,9 @@ def id_diff():
         try:
             dir_path_1, filename_1 = get_text_id_from_file(
                     file=file_1,
-                    upload_dir=current_app.config['UPLOAD_DIR'])
+                    upload_dir=current_app.config['UPLOAD_DIR'],
+                    raw=raw,
+                    logger=logger)
         except TextProcessingError as e:
             error = 'Error converting first draft to text: {}' \
                     .format(str(e))
@@ -353,7 +361,8 @@ def id_diff():
             dir_path_1, filename_1 = get_text_id_from_url(
                                             url_1,
                                             current_app.config['UPLOAD_DIR'],
-                                            logger)
+                                            raw=raw,
+                                            logger=logger)
         except DownloadError as e:
             return jsonify(error=str(e)), BAD_REQUEST
         except TextProcessingError as e:
@@ -367,7 +376,9 @@ def id_diff():
         try:
             dir_path_2, filename_2 = get_text_id_from_file(
                     file=file_2,
-                    upload_dir=current_app.config['UPLOAD_DIR'])
+                    upload_dir=current_app.config['UPLOAD_DIR'],
+                    raw=raw,
+                    logger=logger)
         except TextProcessingError as e:
             error = 'Error converting second draft to text: {}' \
                     .format(str(e))
@@ -416,7 +427,8 @@ def id_diff():
             dir_path_2, filename_2 = get_text_id_from_url(
                                             url_2,
                                             current_app.config['UPLOAD_DIR'],
-                                            logger)
+                                            raw=raw,
+                                            logger=logger)
         except DownloadError as e:
             return jsonify(error=str(e)), BAD_REQUEST
         except TextProcessingError as e:
@@ -480,7 +492,7 @@ def abnf_extract():
         _, filename = get_text_id_from_url(
                                             url,
                                             current_app.config['UPLOAD_DIR'],
-                                            logger)
+                                            logger=logger)
 
         output = extract_abnf(filename, logger=logger)
 

--- a/at/utils/text.py
+++ b/at/utils/text.py
@@ -11,20 +11,26 @@ class TextProcessingError(Exception):
     pass
 
 
-def get_text_id_from_file(file, upload_dir, logger=getLogger()):
+def get_text_id_from_file(file, upload_dir, raw=False, logger=getLogger()):
     '''Save file and returns text draft'''
 
     (dir_path, filename) = save_file(file, upload_dir)
 
-    return get_text_id(dir_path, filename, logger)
+    if not raw:
+        (dir_path, filename) = get_text_id(dir_path, filename, logger)
+
+    return (dir_path, filename)
 
 
-def get_text_id_from_url(url, upload_dir, logger=getLogger()):
+def get_text_id_from_url(url, upload_dir, raw=False, logger=getLogger()):
     '''Save file from URL and returns text draft'''
 
     (dir_path, filename) = save_file_from_url(url, upload_dir)
 
-    return get_text_id(dir_path, filename, logger)
+    if not raw:
+        (dir_path, filename) = get_text_id(dir_path, filename, logger)
+
+    return (dir_path, filename)
 
 
 def get_text_id(dir_path, filename, logger=getLogger()):

--- a/tests/data/draft-smoke-signals-01.xml
+++ b/tests/data/draft-smoke-signals-01.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?rfc toc="yes"?>
+<?rfc sortrefs="yes"?>
+<?rfc symrefs="yes"?>
+<?rfc comments="yes"?>
+
+<rfc ipr="trust200902" docName="draft-smoke-signals-01" category="exp" version="3">
+  <front>
+    <title abbrev="smoke-signals">Standard for Data Transmission via Smoke Signals</title>
+    <author initials="K." asciiSurname="Nanayakkara Rathnayake" surname="Nanayakkara Rathnayake" asciiFullname="Kesara Nanayakkara Rathnayake" fullname="&#3482;&#3545;&#3523;&#3515; &#3505;&#3535;&#3505;&#3535;&#3514;&#3482;&#3530;&#3482;&#3535;&#3515; &#3515;&#3501;&#3530;&#3505;&#3535;&#3514;&#3482;">
+      <address>
+        <postal>
+          <country>New Zealand</country>
+        </postal>
+        <email>kesara@fq.nz</email>
+      </address>
+    </author>
+
+    <abstract>
+    <t>This draft describes a standard to transmit information via smoke signals
+effectively.</t>
+    </abstract>
+  </front>
+
+  <middle>
+    <section anchor="introduction" title="Introduction">
+      <t>Smoke signal is a form of visual communication used over a long
+      distance. It is one of the oldest forms of long distance communcation
+      methods that has been used by many in many different countries throughout
+      the history.</t>
+    </section>
+  </middle>
+
+  <back>
+  </back>
+</rfc>

--- a/tests/test_api_iddiff.py
+++ b/tests/test_api_iddiff.py
@@ -12,7 +12,8 @@ from at import create_app
 TEST_DATA_DIR = './tests/data/'
 DRAFT_A = 'draft-smoke-signals-00.txt'
 DRAFT_B = 'draft-smoke-signals-01.txt'
-XML_DRAFT = 'draft-smoke-signals-00.xml'
+XML_DRAFT_A = 'draft-smoke-signals-00.xml'
+XML_DRAFT_B = 'draft-smoke-signals-01.xml'
 TEST_UNSUPPORTED_FORMAT = 'draft-smoke-signals-00.odt'
 TEST_XML_ERROR = 'draft-smoke-signals-00.error.xml'
 TEMPORARY_DATA_DIR = './tests/tmp/'
@@ -207,6 +208,28 @@ class TestApiIddiff(TestCase):
                 self.assertIn(b'<html', data)
                 self.assertIn(str.encode(DRAFT_A), data)
                 self.assertIn(str.encode(DRAFT_B), data)
+
+    def test_iddiff_with_two_files_raw(self):
+        with self.app.test_client() as client:
+            with self.app.app_context():
+                result = client.post(
+                        '/api/iddiff',
+                        data={
+                            'file_1': (
+                                open(get_path(XML_DRAFT_A), 'rb'),
+                                XML_DRAFT_A),
+                            'file_2': (
+                                open(get_path(XML_DRAFT_B), 'rb'),
+                                XML_DRAFT_B),
+                            'raw': 1,
+                            'apikey': VALID_API_KEY})
+
+                data = result.get_data()
+
+                self.assertEqual(result.status_code, 200)
+                self.assertIn(b'<html', data)
+                self.assertIn(str.encode(XML_DRAFT_A), data)
+                self.assertIn(str.encode(XML_DRAFT_B), data)
 
     def test_iddiff_with_two_files_use_iddiff(self):
         with self.app.test_client() as client:
@@ -413,18 +436,18 @@ class TestApiIddiff(TestCase):
                         '/api/iddiff',
                         data={
                             'file_1': (
-                                open(get_path(XML_DRAFT), 'rb'),
-                                XML_DRAFT),
+                                open(get_path(XML_DRAFT_A), 'rb'),
+                                XML_DRAFT_A),
                             'file_2': (
-                                open(get_path(XML_DRAFT), 'rb'),
-                                XML_DRAFT),
+                                open(get_path(XML_DRAFT_A), 'rb'),
+                                XML_DRAFT_A),
                             'apikey': VALID_API_KEY})
 
                 data = result.get_data()
 
                 self.assertEqual(result.status_code, 200)
                 self.assertIn(b'<html', data)
-                self.assertIn(str.encode(XML_DRAFT.split('.')[0]), data)
+                self.assertIn(str.encode(XML_DRAFT_A.split('.')[0]), data)
 
     def test_iddiff_with_table_only(self):
         labels = [

--- a/tests/test_utils_text.py
+++ b/tests/test_utils_text.py
@@ -85,3 +85,26 @@ class TestUtilsText(TestCase):
         url = 'https://author-tools.ietf.org/sitemap.xml'
         with self.assertRaises(TextProcessingError):
             get_text_id_from_url(url, TEMPORARY_DATA_DIR)
+
+    def test_get_text_id_from_file_raw(self):
+        for filename in TEST_DATA:
+            suffix = f".{filename.split('.')[-1]}"
+            with open(''.join([TEST_DATA_DIR, filename]), 'rb') as file:
+                file_object = FileStorage(file, filename=filename)
+                (dir_path, file_path) = get_text_id_from_file(
+                                            file_object,
+                                            TEMPORARY_DATA_DIR,
+                                            raw=True)
+                self.assertTrue(Path(dir_path).exists())
+                self.assertTrue(Path(file_path).exists())
+                self.assertEqual(Path(file_path).suffix, suffix)
+
+    def test_get_text_id_from_url_raw(self):
+        url = 'https://www.ietf.org/archive/id/draft-iab-xml2rfcv2-01.xml'
+        (dir_path, file_path) = get_text_id_from_url(
+                                    url,
+                                    TEMPORARY_DATA_DIR,
+                                    raw=True)
+        self.assertTrue(Path(dir_path).exists())
+        self.assertTrue(Path(file_path).exists())
+        self.assertEqual(Path(file_path).suffix, '.xml')


### PR DESCRIPTION
This change introduces a new parameter `raw`.
When this parameter is set files will not be converted to text.

Fixes #281