### PR TITLE
feat: Expose kramdown-rfc-clean-svg-ids

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -718,21 +718,69 @@ paths:
                   description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well. (optional)
       responses:
         '200':
-          description: Returns draft in requested format.
+          description: Returns svgcheck output
           content:
-            application/xml:
+            application/json:
               schema:
                 type: object
                 properties:
                   svg:
                     type: string
-                    description: Parsed SVG outpu
+                    description: Parsed SVG output
                   svgcheck:
                     type: string
                     description: svgcheck output logs
                   errors:
                     type: string
                     description: svgcheck errors
+        '400':
+          description: Error has occured.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error description
+        '401':
+          description: Failed to authenticate.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error description
+  /api/clean_svg_ids:
+    post:
+      summary: Changes SVG duplicate ids in SVG
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: XML file with .xml extension
+                apikey:
+                  type: string
+                  description: Personal API can be generated from datatracker (https://datatracker.ietf.org/accounts/apikey). API Key can be submitted as X-API-KEY in headers as well. (optional)
+      responses:
+        '200':
+          description: Returns temporary URL to the draft in requested format.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url:
+                    type: string
+                    description: Temporary URL to requested format
         '400':
           description: Error has occured.
           content:

--- a/at/utils/file.py
+++ b/at/utils/file.py
@@ -11,7 +11,10 @@ from werkzeug.utils import secure_filename
 
 
 ALLOWED_EXTENSIONS = ('txt', 'xml', 'md', 'mkd',)
-ALLOWED_EXTENSIONS_BY_PROCESS = {'svgcheck': ('svg', )}
+ALLOWED_EXTENSIONS_BY_PROCESS = {
+        'svgcheck': ('svg', ),
+        'clean_svg_ids': ('xml', ),
+        }
 DIR_MODE = 0o770
 DRAFT_NAME = re_compile(r'(-\d+)?(\..*)?$')
 DRAFT_NAME_WITH_REVISION = re_compile(r'\..*$')
@@ -158,6 +161,8 @@ def check_file(f, *args, **kwargs):
     file_check_process = None
     if '/svgcheck' in request.path:
         file_check_process = 'svgcheck'
+    if '/clean_svg_ids' in request.path:
+        file_check_process = 'clean_svg_ids'
 
     for file_entry in request.files:
         file = request.files[file_entry]

--- a/at/utils/processor.py
+++ b/at/utils/processor.py
@@ -265,3 +265,20 @@ def get_pdf(filename, logger=getLogger()):
 
     logger.info('new file saved at {}'.format(pdf_file))
     return (pdf_file, process_xml2rfc_log(output, filename))
+
+
+def clean_svg_ids(filename, logger=getLogger()):
+    '''Clean SVGs with duplicates IDs in XML'''
+    logger.debug('invoking kramdown-rfc-clean-svg-ids')
+
+    output = proc_run(
+                args=['kramdown-rfc-clean-svg-ids', filename],
+                capture_output=True)
+
+    # write output to XML file
+    xml_file = get_filename(filename, 'xml')
+    with open(xml_file, 'wb') as file:
+        file.write(output.stdout)
+
+    logger.info('new file saved at {}'.format(xml_file))
+    return xml_file

--- a/tests/data/draft-smoke-signals-02.xml
+++ b/tests/data/draft-smoke-signals-02.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?rfc toc="yes"?>
+<?rfc sortrefs="yes"?>
+<?rfc symrefs="yes"?>
+<?rfc comments="yes"?>
+
+<rfc ipr="trust200902" docName="draft-smoke-signals-02" category="exp" version="3">
+  <front>
+    <title abbrev="smoke-signals">Standard for Data Transmission via Smoke Signals</title>
+    <author initials="K." asciiSurname="Nanayakkara Rathnayake" surname="Nanayakkara Rathnayake" asciiFullname="Kesara Nanayakkara Rathnayake" fullname="&#3482;&#3545;&#3523;&#3515; &#3505;&#3535;&#3505;&#3535;&#3514;&#3482;&#3530;&#3482;&#3535;&#3515; &#3515;&#3501;&#3530;&#3505;&#3535;&#3514;&#3482;">
+      <address>
+        <postal>
+          <country>New Zealand</country>
+        </postal>
+        <email>kesara@fq.nz</email>
+      </address>
+    </author>
+
+    <abstract>
+    <t>This draft describes a standard to transmit information via smoke signals
+effectively.</t>
+    </abstract>
+  </front>
+
+  <middle>
+    <section anchor="introduction" title="Introduction">
+      <t>Smoke signal is a form of visual communication used over a long
+      distance. It is one of the oldest forms of long distance communcation
+      methods that has been used by many in many different countries throughout
+      the history.</t>
+      <artwork type="svg" name="ietf.svg">
+        <svg xmlns="http://www.w3.org/2000/svg" width="175" height="57" viewBox="0 0 175 57">
+          <path id="introduction" d="M60,2l12,12l-12,12l-12-12zM88,2l12,12l-12,12l-12-12zM116,2l12,12l-12,12l-12-12zM18,16l12,12l-12,12l-12-12zM46,16l12,12l-12,12l-12-12zM74,16l12,12l-12,12l-12-12zM102,16l12,12l-12,12l-12-12zM130,16l12,12l-12,12l-12-12zM158,16l12,12l-12,12l-12-12zM60,30l12,12l-12,12l-12-12zM88,30l12,12l-12,12l-12-12zM116,30l12,12l-12,12l-12-12z" fill="black"/>
+          <path stroke="black" stroke-width="0.5" d="M7,27h26l13,13l14-14l14,14l28-28l14,14l14-14l15,15h26v3h-27l-14-14l-14,14l-14-14l-28,28l-14-14l-14,14l-14-14h-25z" fill="white"/>
+          <path d="M3,26h5v5h-5zM168,26h5v5h-5z"/>
+        </svg>
+      </artwork>
+      <artwork type="svg" name="ietf-1.svg">
+        <svg xmlns="http://www.w3.org/2000/svg" width="175" height="57" viewBox="0 0 175 57">
+          <path id="introduction" d="M60,2l12,12l-12,12l-12-12zM88,2l12,12l-12,12l-12-12zM116,2l12,12l-12,12l-12-12zM18,16l12,12l-12,12l-12-12zM46,16l12,12l-12,12l-12-12zM74,16l12,12l-12,12l-12-12zM102,16l12,12l-12,12l-12-12zM130,16l12,12l-12,12l-12-12zM158,16l12,12l-12,12l-12-12zM60,30l12,12l-12,12l-12-12zM88,30l12,12l-12,12l-12-12zM116,30l12,12l-12,12l-12-12z" fill="black"/>
+          <path stroke="black" stroke-width="0.5" d="M7,27h26l13,13l14-14l14,14l28-28l14,14l14-14l15,15h26v3h-27l-14-14l-14,14l-14-14l-28,28l-14-14l-14,14l-14-14h-25z" fill="white"/>
+          <path d="M3,26h5v5h-5zM168,26h5v5h-5z"/>
+        </svg>
+      </artwork>
+    </section>
+  </middle>
+
+  <back>
+  </back>
+</rfc>

--- a/tests/test_api_clean_svg_ids.py
+++ b/tests/test_api_clean_svg_ids.py
@@ -1,0 +1,107 @@
+from logging import disable as set_logger, INFO, CRITICAL
+from os.path import abspath
+from pathlib import Path
+from shutil import rmtree
+from unittest import TestCase
+
+from at import create_app
+
+TEST_DATA_DIR = './tests/data/'
+TEST_XML_DRAFT = 'draft-smoke-signals-02.xml'
+TEST_UNSUPPORTED_FORMAT = 'draft-smoke-signals-00.odt'
+TEMPORARY_DATA_DIR = './tests/tmp/'
+VALID_API_KEY = 'foobar'
+SITE_URL = 'https://example.org'
+
+
+def get_path(filename):
+    '''Returns file path'''
+    return ''.join([TEST_DATA_DIR, filename])
+
+
+class TestApiCleanSvgIds(TestCase):
+    '''Tests for /api/clean_svg_ids end point'''
+
+    def setUp(self):
+        # susspress logging messages
+        set_logger(CRITICAL)
+        # create temporary data dir
+        Path(TEMPORARY_DATA_DIR).mkdir(exist_ok=True)
+
+        config = {
+                'UPLOAD_DIR': abspath(TEMPORARY_DATA_DIR),
+                'REQUIRE_AUTH': False,
+                'SITE_URL': SITE_URL}
+
+        self.app = create_app(config)
+
+    def tearDown(self):
+        # set logging to INFO
+        set_logger(INFO)
+        # remove temporary data dir
+        rmtree(TEMPORARY_DATA_DIR, ignore_errors=True)
+
+    def test_no_file(self):
+        with self.app.test_client() as client:
+            with self.app.app_context():
+                result = client.post(
+                        '/api/clean_svg_ids',
+                        data={'apikey': VALID_API_KEY})
+                json_data = result.get_json()
+
+                self.assertEqual(result.status_code, 400)
+                self.assertEqual(json_data['error'], 'No file')
+
+    def test_missing_file_name(self):
+        with self.app.test_client() as client:
+            with self.app.app_context():
+                result = client.post(
+                        '/api/clean_svg_ids',
+                        data={
+                            'file': (
+                                open(get_path(TEST_XML_DRAFT), 'rb'),
+                                ''),
+                            'apikey': VALID_API_KEY})
+                json_data = result.get_json()
+
+                self.assertEqual(result.status_code, 400)
+                self.assertEqual(json_data['error'], 'Filename is missing')
+
+    def test_unsupported_file_format(self):
+        with self.app.test_client() as client:
+            with self.app.app_context():
+                result = client.post(
+                        '/api/clean_svg_ids',
+                        data={
+                            'file': (
+                                open(get_path(TEST_UNSUPPORTED_FORMAT), 'rb'),
+                                TEST_UNSUPPORTED_FORMAT),
+                            'apikey': VALID_API_KEY})
+                json_data = result.get_json()
+
+                self.assertEqual(result.status_code, 400)
+                self.assertEqual(
+                        json_data['error'],
+                        'Input file format not supported')
+
+    def test_clean_svg_ids(self):
+        with self.app.test_client() as client:
+            with self.app.app_context():
+                result = client.post(
+                        '/api/clean_svg_ids',
+                        data={
+                            'file': (
+                                open(get_path(TEST_XML_DRAFT), 'rb'),
+                                TEST_XML_DRAFT),
+                            'apikey': VALID_API_KEY})
+                json_data = result.get_json()
+
+                self.assertEqual(result.status_code, 200)
+                self.assertTrue(json_data['url'].startswith(
+                                                '{}/'.format(SITE_URL)))
+
+                # test export
+                export_url = json_data['url'].replace(SITE_URL, '')
+                export = client.get(export_url)
+                self.assertEqual(export.status_code, 200)
+                self.assertIsNotNone(export.data)

--- a/tests/test_utils_processor.py
+++ b/tests/test_utils_processor.py
@@ -6,8 +6,9 @@ from unittest import TestCase
 from werkzeug.datastructures import FileStorage
 
 from at.utils.processor import (
-        convert_v2v3, get_html, get_pdf, get_text, get_xml, kramdown2xml,
-        md2xml, mmark2xml, process_file, txt2xml, MmarkError, XML2RFCError)
+        clean_svg_ids, convert_v2v3, get_html, get_pdf, get_text, get_xml,
+        kramdown2xml, md2xml, mmark2xml, process_file, txt2xml, MmarkError,
+        XML2RFCError)
 
 TEST_DATA_DIR = './tests/data/'
 TEST_XML_DRAFT = 'draft-smoke-signals-00.xml'
@@ -158,3 +159,10 @@ class TestUtilsProcessor(TestCase):
         with self.assertRaises(XML2RFCError):
             saved_file, logs = get_pdf(
                     ''.join([TEMPORARY_DATA_DIR, TEST_XML_ERROR]))
+
+    def test_clean_svg_ids(self):
+        saved_file = clean_svg_ids(
+                ''.join([TEMPORARY_DATA_DIR, TEST_XML_DRAFT]))
+
+        self.assertTrue(Path(saved_file).exists())
+        self.assertEqual(Path(saved_file).suffix, '.xml')


### PR DESCRIPTION
New API call `/api/clean_svg_ids` to fix duplicate SVG `id` attributes in XML.

Fixes #327