### PR TITLE
fix: Use correct domain in ALLOWED_DOMAINS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN mkdir -p tmp && \
     echo "VERSION = '0.15.4'" >> at/config.py && \
     echo "REQUIRE_AUTH = False" >> at/config.py && \
     echo "DT_LATEST_DRAFT_URL = 'https://datatracker.ietf.org/api/rfcdiff-latest-json'" >> at/config.py && \
-    echo "ALLOWED_DOMAINS = ['ietf.org', 'rfc-editor.org', 'github.com', 'githubusercontent.com', 'github.io', 'gitlab.com', 'gitlab.io', 'codeberg.pages']" >> at/config.py
+    echo "ALLOWED_DOMAINS = ['ietf.org', 'rfc-editor.org', 'github.com', 'githubusercontent.com', 'github.io', 'gitlab.com', 'gitlab.io', 'codeberg.page']" >> at/config.py
 
 # host with waitress
 CMD python3 serve.py


### PR DESCRIPTION
The entry added in https://github.com/ietf-tools/ietf-at/pull/344 was incorrectly using the plural TLD, when the actual TLD is singular ".page".

Sorry for the churn. Pinging @kesara, who should have all the context from yesterday's issue.