### PR TITLE
chore: Make number of gunicorn works configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ENV PATH=$PATH:./node_modules/.bin
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 # Disable local file read for kramdown-rfc
 ENV KRAMDOWN_SAFE=1
+# Number of gunicorn workers
+ENV GUNICORN_WORKERS=4
 
 WORKDIR /usr/src/app
 
@@ -100,4 +102,4 @@ RUN mkdir -p tmp && \
     echo "ALLOWED_DOMAINS = ['ietf.org', 'rfc-editor.org', 'github.com', 'githubusercontent.com', 'github.io', 'gitlab.com', 'gitlab.io', 'codeberg.page']" >> at/config.py
 
 # host with gunicorn
-CMD gunicorn --workers=16 -b 0.0.0.0:80 'at:create_app()'
+CMD gunicorn --workers=$GUNICORN_WORKERS -b 0.0.0.0:80 'at:create_app()'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,5 @@ services:
     build: .
     ports:
       - '8888:80'
+    environment:
+      - GUNICORN_WORKERS=4


### PR DESCRIPTION
Number of gunicorn workers can be configured by setting enviroment variable `GUNICORN_WORKERS`.
Default value is 4.

Fixes #405